### PR TITLE
Remote repository

### DIFF
--- a/pydriller/__init__.py
+++ b/pydriller/__init__.py
@@ -1,2 +1,2 @@
-from .repository_mining import RepositoryMining, GitRepository
 from .domain.commit import Commit
+from .repository_mining import RepositoryMining, GitRepository

--- a/pydriller/domain/commit.py
+++ b/pydriller/domain/commit.py
@@ -14,11 +14,11 @@
 import logging
 import os
 from _datetime import datetime
-from typing import List, Set, Dict
 from enum import Enum
+from typing import List, Set, Dict
+
 import lizard
 from git import Repo, Diff, Git, Commit as GitCommit
-
 
 logger = logging.getLogger(__name__)
 from pydriller.domain.developer import Developer
@@ -187,23 +187,24 @@ class Modification:
 
     def __str__(self):
         return (
-            'MODIFICATION\n' +
-            'Old Path: {}\n'.format(self.old_path) +
-            'New Path: {}\n'.format(self.new_path) +
-            'Type: {}\n'.format(self.change_type.name) +
-            'Diff: {}\n'.format(self.diff) +
-            'Source code: {}\n'.format(self.source_code)
+                'MODIFICATION\n' +
+                'Old Path: {}\n'.format(self.old_path) +
+                'New Path: {}\n'.format(self.new_path) +
+                'Type: {}\n'.format(self.change_type.name) +
+                'Diff: {}\n'.format(self.diff) +
+                'Source code: {}\n'.format(self.source_code)
         )
 
 
 class Commit:
-    def __init__(self, commit: GitCommit, path: str, main_branch: str) -> None:
+    def __init__(self, commit: GitCommit, path: str, project_name: str, main_branch: str) -> None:
         """
         Create a commit object.
         """
         self._c_object = commit
         self._path = path
         self._main_branch = main_branch
+        self.project_name = project_name
 
     @property
     def hash(self) -> str:
@@ -383,16 +384,22 @@ class Commit:
 
     def __str__(self):
         return ('Hash: {}'.format(self.hash) + '\n'
-                'Author: {}'.format(self.author.name) + '\n'
-                'Author email: {}'.format(self.author.email) + '\n'
-                'Committer: {}'.format(self.committer.name) + '\n'
-                'Committer email: {}'.format(self.committer.email) + '\n'
-                'Author date: {}'.format(self.author_date.strftime("%Y-%m-%d %H:%M:%S")) + '\n'
-                'Committer date: {}'.format(self.committer_date.strftime("%Y-%m-%d %H:%M:%S")) + '\n'
-                'Message: {}'.format(self.msg) + '\n'
-                'Parent: {}'.format("\n".join(map(str, self.parents))) + '\n'
-                'Merge: {}'.format(self.merge) + '\n'
-                'Modifications: \n{}'.format("\n".join(map(str, self.modifications))) + '\n'
-                'Branches: \n{}'.format("\n".join(map(str, self.branches))) + '\n'
-                'In main branch: {}'.format(self.in_main_branch)
+                                               'Author: {}'.format(self.author.name) + '\n'
+                                                                                       'Author email: {}'.format(
+            self.author.email) + '\n'
+                                 'Committer: {}'.format(self.committer.name) + '\n'
+                                                                               'Committer email: {}'.format(
+            self.committer.email) + '\n'
+                                    'Author date: {}'.format(self.author_date.strftime("%Y-%m-%d %H:%M:%S")) + '\n'
+                                                                                                               'Committer date: {}'.format(
+            self.committer_date.strftime("%Y-%m-%d %H:%M:%S")) + '\n'
+                                                                 'Message: {}'.format(self.msg) + '\n'
+                                                                                                  'Parent: {}'.format(
+            "\n".join(map(str, self.parents))) + '\n'
+                                                 'Merge: {}'.format(self.merge) + '\n'
+                                                                                  'Modifications: \n{}'.format(
+            "\n".join(map(str, self.modifications))) + '\n'
+                                                       'Branches: \n{}'.format(
+            "\n".join(map(str, self.branches))) + '\n'
+                                                  'In main branch: {}'.format(self.in_main_branch)
                 )

--- a/pydriller/repository_mining.py
+++ b/pydriller/repository_mining.py
@@ -43,7 +43,7 @@ class RepositoryMining:
         """
         Init a repository mining.
 
-        :param str path_to_repo: absolute path to the repository you have to analyze
+        :param str or List[str] path_to_repo: absolute path to the repository (or list of absolute paths) you have to analyze
         :param str single: hash of a single commit to analyze
         :param datetime since: starting date
         :param datetime to: ending date

--- a/pydriller/repository_mining.py
+++ b/pydriller/repository_mining.py
@@ -23,6 +23,7 @@ from datetime import datetime
 from git import Repo
 import tempfile
 import os
+import shutil
 
 logger = logging.getLogger(__name__)
 
@@ -129,6 +130,7 @@ class RepositoryMining:
         else:
             self._path_to_repo = []
 
+        tmp_folder = None
         if self._path_to_remote_repo is not None:
             if isinstance(self._path_to_repo, str):
                 self._path_to_remote_repo = [self._path_to_remote_repo]
@@ -160,6 +162,9 @@ class RepositoryMining:
                     continue
 
                 yield commit
+
+        # clean up!
+        self.cleanup(tmp_folder)
 
     def _is_commit_filtered(self, commit: Commit):
         if self.only_in_main_branch is True and commit.in_main_branch is False:
@@ -227,3 +232,10 @@ class RepositoryMining:
 
         return url[last_slash_index + 1:last_suffix_index]
 
+    def cleanup(self, tmp_folder):
+        if not tmp_folder is None:
+            logger.info("Deleting folder {}".format(tmp_folder))
+            if os.path.isdir(tmp_folder):
+                shutil.rmtree(tmp_folder)
+            else:
+                logger.info("Could not find the temporary folder, maybe already deleted?")

--- a/pydriller/repository_mining.py
+++ b/pydriller/repository_mining.py
@@ -12,19 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import atexit
 import logging
-
-import pytz as pytz
-
-from pydriller.domain.commit import Commit
-from typing import List, Generator, Union
-from pydriller.git_repository import GitRepository
-from datetime import datetime
-from git import Repo, GitCommandError
-import tempfile
 import os
 import shutil
-import atexit
+import tempfile
+from datetime import datetime
+from typing import List, Generator, Union
+
+import pytz as pytz
+from git import Repo, GitCommandError
+
+from pydriller.domain.commit import Commit
+from pydriller.git_repository import GitRepository
 
 logger = logging.getLogger(__name__)
 
@@ -37,7 +37,7 @@ class RepositoryMining:
                  from_tag: str = None, to_tag: str = None,
                  reversed_order: bool = False,
                  only_in_main_branch: bool = False,
-                 only_in_branches: List[str]= None,
+                 only_in_branches: List[str] = None,
                  only_modifications_with_file_types: List[str] = None,
                  only_no_merge: bool = False):
         """
@@ -81,7 +81,7 @@ class RepositoryMining:
     def _sanity_check_filters(self, git_repo, from_commit, from_tag, since, single, to, to_commit, to_tag):
         if single is not None:
             if since is not None or to is not None or from_commit is not None or \
-                   to_commit is not None or from_tag is not None or to_tag is not None:
+                    to_commit is not None or from_tag is not None or to_tag is not None:
                 raise Exception('You can not specify a single commit with other filters')
 
         if from_commit is not None:
@@ -155,7 +155,7 @@ class RepositoryMining:
 
             for commit in all_cs:
                 logger.info('Commit #{} in {} from {}'
-                             .format(commit.hash, commit.author_date, commit.author.name))
+                            .format(commit.hash, commit.author_date, commit.author.name))
 
                 if self._is_commit_filtered(commit):
                     logger.info('Commit #{} filtered'.format(commit.hash))

--- a/tests/test_git_repository.py
+++ b/tests/test_git_repository.py
@@ -17,7 +17,16 @@ import pytest
 from pydriller.git_repository import GitRepository
 from pydriller.domain.commit import ModificationType
 from datetime import datetime, timezone, timedelta
+
 logging.basicConfig(format='%(asctime)s - %(levelname)s - %(message)s', level=logging.INFO)
+
+
+def test_projectname():
+    gr = GitRepository('test-repos/test1/')
+    assert gr.project_name == "test1"
+
+    gr = GitRepository('test-repos/test1')
+    assert gr.project_name == "test1"
 
 
 def test_get_head():
@@ -66,10 +75,11 @@ def test_get_first_commit():
     assert 'a88c84ddf42066611e76e6cb690144e5357d132c' == c.hash
     assert 'ishepard' == c.author.name
     assert 'ishepard' == c.committer.name
-    assert datetime(2018,3,22,10,41,11,tzinfo=to_zone).timestamp() == c.author_date.timestamp()
+    assert datetime(2018, 3, 22, 10, 41, 11, tzinfo=to_zone).timestamp() == c.author_date.timestamp()
     assert 2 == len(c.modifications)
     assert 'First commit adding 2 files' == c.msg
     assert c.in_main_branch is True
+
 
 def test_files():
     gr = GitRepository('test-repos/test2/')
@@ -118,6 +128,7 @@ def test_list_files_in_commit():
     assert 3 == len(files3)
     gr.reset()
 
+
 def test_checkout_with_commit_not_fully_merged_to_master():
     gr = GitRepository('test-repos/git-9/')
     gr.checkout('developing')
@@ -131,6 +142,7 @@ def test_checkout_with_commit_not_fully_merged_to_master():
     files1 = gr.files()
     assert 2 == len(files1)
     gr.reset()
+
 
 def test_get_all_commits():
     gr = GitRepository('test-repos/git-1/')
@@ -253,6 +265,7 @@ def test_diffs():
             assert 12 == mod.removed
             assert 0 == mod.added
 
+
 def test_detail_rename():
     gr = GitRepository('test-repos/git-1/')
     commit = gr.get_commit('f0dd1308bd904a9b108a6a40865166ee962af3d4')
@@ -359,6 +372,7 @@ def test_get_commits_last_modified_lines_for_single_file():
 
     assert len(buggy_commits) == 1
     assert 'e2ed043eb96c05ebde653a44ae733ded9ef90750' in buggy_commits
+
 
 def test_get_commits_last_modified_lines_with_more_modification():
     gr = GitRepository('test-repos/test5/')

--- a/tests/test_ranges.py
+++ b/tests/test_ranges.py
@@ -149,19 +149,25 @@ def test_multiple_filters_exceptions():
     from_tag = 'v1.4'
 
     with pytest.raises(Exception):
-        RepositoryMining('test-repos/test1/', from_commit=from_commit, from_tag=from_tag)
+        for commit in RepositoryMining('test-repos/test1/', from_commit=from_commit, from_tag=from_tag).traverse_commits():
+            print(commit.hash)
 
     with pytest.raises(Exception):
-        RepositoryMining('test-repos/test1/', since=dt2, from_commit=from_commit)
+        for commit in RepositoryMining('test-repos/test1/', since=dt2, from_commit=from_commit).traverse_commits():
+            print(commit.hash)
 
     with pytest.raises(Exception):
-        RepositoryMining('test-repos/test1/', since=dt2, from_tag=from_tag)
+        for commit in RepositoryMining('test-repos/test1/', since=dt2, from_tag=from_tag).traverse_commits():
+            print(commit.hash)
 
     with pytest.raises(Exception):
-        RepositoryMining('test-repos/test1/', to=dt2, to_tag=from_tag)
+        for commit in RepositoryMining('test-repos/test1/', to=dt2, to_tag=from_tag).traverse_commits():
+            print(commit.hash)
 
     with pytest.raises(Exception):
-        RepositoryMining('test-repos/test1/', single=from_commit, to=dt2, to_tag=from_tag)
+        for commit in RepositoryMining('test-repos/test1/', single=from_commit, to=dt2, to_tag=from_tag).traverse_commits():
+            print(commit.hash)
 
     with pytest.raises(Exception):
-        RepositoryMining('test-repos/test1/', to_commit=from_commit, to=dt2)
+        for commit in RepositoryMining('test-repos/test1/', to_commit=from_commit, to=dt2).traverse_commits():
+            print(commit.hash)

--- a/tests/test_repository_mining.py
+++ b/tests/test_repository_mining.py
@@ -1,0 +1,45 @@
+from datetime import datetime
+
+import pytest
+
+from pydriller import RepositoryMining
+import logging
+logging.basicConfig(format='%(asctime)s - %(levelname)s - %(message)s', level=logging.INFO)
+
+
+def test_no_url():
+    with pytest.raises(Exception):
+        for commit in RepositoryMining().traverse_commits():
+            c = commit.hash
+
+
+def test_simple_url():
+    assert 5 == len(list(RepositoryMining(path_to_repo="test-repos/test1").traverse_commits()))
+
+
+def test_two_local_urls():
+    urls = ["test-repos/test1", "test-repos/test3"]
+    assert 11 == len(list(RepositoryMining(path_to_repo=urls).traverse_commits()))
+
+
+def test_simple_remote_url():
+    dt2 = datetime(2018, 10, 20)
+    assert 158 == len(list(RepositoryMining(path_to_remote_repo="https://github.com/ishepard/pydriller.git", to=dt2).traverse_commits()))
+
+
+def test_two_remote_urls():
+    urls = ["https://github.com/mauricioaniche/repodriller.git", "https://github.com/ishepard/pydriller.git"]
+    dt2 = datetime(2018, 10, 20)
+    assert 517 == len(list(RepositoryMining(path_to_remote_repo=urls, to=dt2).traverse_commits()))
+
+
+def test_2_identical_local_urls():
+    urls = ["test-repos/test1", "test-repos/test1"]
+    assert 10 == len(list(RepositoryMining(path_to_repo=urls).traverse_commits()))
+
+
+def test_2_identical_remote_urls():
+    urls = ["https://github.com/ishepard/pydriller.git", "https://github.com/ishepard/pydriller.git"]
+    dt2 = datetime(2018, 10, 20)
+    with pytest.raises(Exception):
+        list(RepositoryMining(path_to_remote_repo=urls, to=dt2).traverse_commits())

--- a/tests/test_repository_mining.py
+++ b/tests/test_repository_mining.py
@@ -10,8 +10,7 @@ logging.basicConfig(format='%(asctime)s - %(levelname)s - %(message)s', level=lo
 # It should fail when no URLs are specified
 def test_no_url():
     with pytest.raises(Exception):
-        for commit in RepositoryMining().traverse_commits():
-            c = commit.hash
+        list(RepositoryMining().traverse_commits())
 
 
 def test_simple_url():

--- a/tests/test_repository_mining.py
+++ b/tests/test_repository_mining.py
@@ -7,6 +7,7 @@ import logging
 logging.basicConfig(format='%(asctime)s - %(levelname)s - %(message)s', level=logging.INFO)
 
 
+# It should fail when no URLs are specified
 def test_no_url():
     with pytest.raises(Exception):
         for commit in RepositoryMining().traverse_commits():
@@ -38,8 +39,25 @@ def test_2_identical_local_urls():
     assert 10 == len(list(RepositoryMining(path_to_repo=urls).traverse_commits()))
 
 
+# I should fail since the directory already exists
 def test_2_identical_remote_urls():
     urls = ["https://github.com/ishepard/pydriller.git", "https://github.com/ishepard/pydriller.git"]
     dt2 = datetime(2018, 10, 20)
     with pytest.raises(Exception):
         list(RepositoryMining(path_to_remote_repo=urls, to=dt2).traverse_commits())
+
+
+def test_both_local_and_remote_urls():
+    dt2 = datetime(2018, 10, 20)
+    assert 163 == len(list(RepositoryMining(path_to_repo="test-repos/test1",
+                                          path_to_remote_repo="https://github.com/ishepard/pydriller.git",
+                                          to=dt2).traverse_commits()))
+
+
+def test_both_local_and_remote_urls_list():
+    dt2 = datetime(2018, 10, 20)
+    urls_local = ["test-repos/test1", "test-repos/test3"]
+    urls_remote = ["https://github.com/mauricioaniche/repodriller.git", "https://github.com/ishepard/pydriller.git"]
+    assert 528 == len(list(RepositoryMining(path_to_repo=urls_local,
+                                          path_to_remote_repo=urls_remote,
+                                          to=dt2).traverse_commits()))

--- a/tests/test_repository_mining.py
+++ b/tests/test_repository_mining.py
@@ -25,13 +25,13 @@ def test_two_local_urls():
 
 def test_simple_remote_url():
     dt2 = datetime(2018, 10, 20)
-    assert 158 == len(list(RepositoryMining(path_to_remote_repo="https://github.com/ishepard/pydriller.git", to=dt2).traverse_commits()))
+    assert 158 == len(list(RepositoryMining(path_to_repo="https://github.com/ishepard/pydriller.git", to=dt2).traverse_commits()))
 
 
 def test_two_remote_urls():
     urls = ["https://github.com/mauricioaniche/repodriller.git", "https://github.com/ishepard/pydriller.git"]
     dt2 = datetime(2018, 10, 20)
-    assert 517 == len(list(RepositoryMining(path_to_remote_repo=urls, to=dt2).traverse_commits()))
+    assert 517 == len(list(RepositoryMining(path_to_repo=urls, to=dt2).traverse_commits()))
 
 
 def test_2_identical_local_urls():
@@ -44,20 +44,18 @@ def test_2_identical_remote_urls():
     urls = ["https://github.com/ishepard/pydriller.git", "https://github.com/ishepard/pydriller.git"]
     dt2 = datetime(2018, 10, 20)
     with pytest.raises(Exception):
-        list(RepositoryMining(path_to_remote_repo=urls, to=dt2).traverse_commits())
+        list(RepositoryMining(path_to_repo=urls, to=dt2).traverse_commits())
 
 
 def test_both_local_and_remote_urls():
     dt2 = datetime(2018, 10, 20)
-    assert 163 == len(list(RepositoryMining(path_to_repo="test-repos/test1",
-                                          path_to_remote_repo="https://github.com/ishepard/pydriller.git",
-                                          to=dt2).traverse_commits()))
+    assert 163 == len(list(RepositoryMining(path_to_repo=["test-repos/test1","https://github.com/ishepard/pydriller.git"],
+                                            to=dt2).traverse_commits()))
 
 
 def test_both_local_and_remote_urls_list():
     dt2 = datetime(2018, 10, 20)
-    urls_local = ["test-repos/test1", "test-repos/test3"]
-    urls_remote = ["https://github.com/mauricioaniche/repodriller.git", "https://github.com/ishepard/pydriller.git"]
-    assert 528 == len(list(RepositoryMining(path_to_repo=urls_local,
-                                          path_to_remote_repo=urls_remote,
-                                          to=dt2).traverse_commits()))
+    urls = ["test-repos/test1", "https://github.com/mauricioaniche/repodriller.git", "test-repos/test3", "https://github.com/ishepard/pydriller.git"]
+    assert 528 == len(list(RepositoryMining(path_to_repo=urls,
+                                            to=dt2).traverse_commits()))
+


### PR DESCRIPTION
With this PR I address a feature that many users asked me to implement: the possibility of setting a list of remote URLs that PyDriller automatically clone, analyse, and delete.

So now, when initialising RepositoryMining, the field `path_to_repo` is not just a simple str anymore, but can be a list of local or remote URLs. For example, all these can be passed to `RepositoryMining(path_to_repo=url)`:
```
url = "repos/pydriller/"
url = ["repos/pydriller/", "repos/anotherrepo/"]
url = ["repos/pydriller/", "https://github.com/apache/hadoop.git", "repos/anotherrepo"]
url = "https://github.com/apache/hadoop.git"
```
