### PR TITLE
Handle unexpected cases where ModificationType is unknown

### DIFF
--- a/pydriller/domain/commit.py
+++ b/pydriller/domain/commit.py
@@ -31,7 +31,8 @@ class ModificationType(Enum):
     COPY = 2,
     RENAME = 3,
     DELETE = 4,
-    MODIFY = 5
+    MODIFY = 5,
+    UNKNOWN = 6
 
 
 class Method:
@@ -403,6 +404,8 @@ class Commit:
             return ModificationType.RENAME
         elif d.a_blob and d.b_blob and d.a_blob != d.b_blob:
             return ModificationType.MODIFY
+        else:
+            return ModificationType.UNKNOWN
 
     def __eq__(self, other):
         if not isinstance(other, Commit):


### PR DESCRIPTION
There are cases where the ModificationType is not handled correctly. It can happen when the commit refers to 'access permissions' changes only. Commit 8168cbf40b460bb218661c4f2df4a417f7efeb2a of https://github.com/Pr0methean/BetterRandom/ is an example.