### PR TITLE
Install typing only on Python < 3.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 gitpython
-typing
+typing; python_version < '3.5'
 pytz
 lizard


### PR DESCRIPTION
It's part of the standard library starting from 3.5.
See https://github.com/python/typing/issues/573.