### PR TITLE
parsed_diff is in modification

### DIFF
--- a/pydriller/domain/commit.py
+++ b/pydriller/domain/commit.py
@@ -21,7 +21,7 @@ import logging
 from _datetime import datetime
 from enum import Enum
 from pathlib import Path
-from typing import List, Set, Dict
+from typing import List, Set, Dict, Tuple
 
 import lizard
 from git import Diff, Git, Commit as GitCommit, NULL_TREE
@@ -192,6 +192,55 @@ class Modification:  # pylint: disable=R0902
         """
         self._calculate_metrics()
         return self._token_count
+
+    @property
+    def diff_parsed(self) -> Dict[str, List[Tuple[int, str]]]:
+        """
+        Returns a dictionary with the added and deleted lines.
+        The dictionary has 2 keys: "added" and "deleted", each containing the
+        corresponding added or deleted lines. For both keys, the value is a
+        list of Tuple (int, str), corresponding to (number of line in the file,
+        actual line).
+
+        :return: Dictionary
+        """
+        lines = self.diff.split('\n')
+        modified_lines = {'added': [], 'deleted': []}
+
+        count_deletions = 0
+        count_additions = 0
+
+        for line in lines:
+            line = line.rstrip()
+            count_deletions += 1
+            count_additions += 1
+
+            if line.startswith('@@'):
+                count_deletions, count_additions = self._get_line_numbers(line)
+
+            if line.startswith('-'):
+                modified_lines['deleted'].append((count_deletions, line[1:]))
+                count_additions -= 1
+
+            if line.startswith('+'):
+                modified_lines['added'].append((count_additions, line[1:]))
+                count_deletions -= 1
+
+            if line == r'\ No newline at end of file':
+                count_deletions -= 1
+                count_additions -= 1
+
+        return modified_lines
+
+    @staticmethod
+    def _get_line_numbers(line):
+        token = line.split(" ")
+        numbers_old_file = token[1]
+        numbers_new_file = token[2]
+        delete_line_number = int(numbers_old_file.split(",")[0]
+                                 .replace("-", "")) - 1
+        additions_line_number = int(numbers_new_file.split(",")[0]) - 1
+        return delete_line_number, additions_line_number
 
     @property
     def methods(self) -> List[Method]:

--- a/pydriller/git_repository.py
+++ b/pydriller/git_repository.py
@@ -21,7 +21,7 @@ import os
 from pathlib import Path
 from threading import Lock
 from typing import List, Dict, Tuple, Set, Generator
-
+import warnings
 from git import Git, Repo, GitCommandError, Commit as GitCommit
 
 from pydriller.domain.commit import Commit, ModificationType, Modification
@@ -239,6 +239,9 @@ class GitRepository:
         :param str diff: diff of the commit
         :return: Dictionary
         """
+        warnings.warn('parse_diff is deprecated. You can now access the '
+                      'parsed_diff directly from the modification (e.g. '
+                      'modification.diff_parsed)')
         lines = diff.split('\n')
         modified_lines = {'added': [], 'deleted': []}
 

--- a/pydriller/git_repository.py
+++ b/pydriller/git_repository.py
@@ -86,9 +86,10 @@ class GitRepository:
         self._git = Git(str(self.path))
 
     def clear(self):
-        if self.git:
+        if self._git:
             self.git.clear_cache()
-        self.repo.git.clear_cache()
+        if self._repo:
+            self.repo.git.clear_cache()
 
     def _open_repository(self):
         self._repo = Repo(str(self.path))
@@ -326,7 +327,7 @@ class GitRepository:
             if mod.change_type == ModificationType.RENAME or \
                     mod.change_type == ModificationType.DELETE:
                 path = mod.old_path
-            deleted_lines = self.parse_diff(mod.diff)['deleted']
+            deleted_lines = mod.diff_parsed['deleted']
             try:
                 blame = self._get_blame(commit.hash, path,
                                         hashes_to_ignore_path)

--- a/pydriller/repository_mining.py
+++ b/pydriller/repository_mining.py
@@ -20,8 +20,8 @@ import logging
 import os
 import tempfile
 from datetime import datetime
-from typing import List, Generator, Union
 from pathlib import Path
+from typing import List, Generator, Union
 
 from git import Repo
 
@@ -139,8 +139,8 @@ class RepositoryMining:
                 if self._conf.get('clone_repo_to'):
                     clone_folder = str(Path(self._conf.get('clone_repo_to')))
                     if not os.path.isdir(clone_folder):
-                        raise Exception("Not a directory: "\
-                                "{0}".format(clone_folder))
+                        raise Exception("Not a directory: " \
+                                        "{0}".format(clone_folder))
                     path_repo = self._clone_remote_repos(clone_folder,
                                                          path_repo)
                 else:
@@ -176,6 +176,7 @@ class RepositoryMining:
                 yield commit
 
             # cleaning
+            self._conf.set_value("git_repo", None)
             git_repo.clear()
 
     @staticmethod

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -83,11 +83,9 @@ def test_diff_no_newline():
     """
     gr = GitRepository('test-repos/no_newline')
 
-    diff = gr.get_commit('52a78c1ee5d100528eccba0a3d67371dbd22d898').modifications[0].diff
-    parsed_lines = gr.parse_diff(diff)
-
-    added = parsed_lines['added']
-    deleted = parsed_lines['deleted']
+    mod = gr.get_commit('52a78c1ee5d100528eccba0a3d67371dbd22d898').modifications[0]
+    added = mod.diff_parsed['added']
+    deleted = mod.diff_parsed['deleted']
 
     assert (1, 'test1') in deleted  # is considered as deleted as a 'newline' command is added
     assert (1, 'test1') in added  # now with added 'newline'

--- a/tests/test_repository_mining.py
+++ b/tests/test_repository_mining.py
@@ -123,8 +123,7 @@ def test_diff_without_histogram(git_repo):
     commit = list(RepositoryMining('test-repos/histogram',
                                    single="93df8676e6fab70d9677e94fd0f6b17db095e890").traverse_commits())[0]
 
-    mod = commit.modifications[0]
-    diff = git_repo.parse_diff(mod.diff)
+    diff = commit.modifications[0].diff_parsed
     assert len(diff['added']) == 11
     assert (3, '    if (path == null)') in diff['added']
     assert (5, '        log.error("Icon path is null");') in diff['added']
@@ -154,8 +153,7 @@ def test_diff_with_histogram(git_repo):
     commit = list(RepositoryMining('test-repos/histogram',
                                    single="93df8676e6fab70d9677e94fd0f6b17db095e890",
                                    histogram_diff=True).traverse_commits())[0]
-    mod = commit.modifications[0]
-    diff = git_repo.parse_diff(mod.diff)
+    diff = commit.modifications[0].diff_parsed
     assert (4, '    {') in diff["added"]
     assert (5, '        log.error("Icon path is null");') in diff["added"]
     assert (6, '        return null;') in diff["added"]
@@ -190,12 +188,12 @@ def test_ignore_add_whitespaces_and_modified_normal_line(git_repo):
     commit = list(RepositoryMining('test-repos/whitespace',
                                    single="52716ef1f11e07308b5df1b313aec5496d5e91ce").traverse_commits())[0]
     assert len(commit.modifications) == 1
-    parsed_normal_diff = git_repo.parse_diff(commit.modifications[0].diff)
+    parsed_normal_diff = commit.modifications[0].diff_parsed
     commit = list(RepositoryMining('test-repos/whitespace',
                                    skip_whitespaces=True,
                                    single="52716ef1f11e07308b5df1b313aec5496d5e91ce").traverse_commits())[0]
     assert len(commit.modifications) == 1
-    parsed_wo_whitespaces_diff = git_repo.parse_diff(commit.modifications[0].diff)
+    parsed_wo_whitespaces_diff = commit.modifications[0].diff_parsed
     assert len(parsed_normal_diff['added']) == 2
     assert len(parsed_wo_whitespaces_diff['added']) == 1
 


### PR DESCRIPTION
Before this, one has to create a GitRepository object to parse the diff. From now on the `parsed_diff` can be accessed from the modification instead. 

This will help us in the future for the `changed_methods` feature as well. 