### PR TITLE
Solved division by zero bug in history complexity metric

### DIFF
--- a/pydriller/metrics/process/history_complexity.py
+++ b/pydriller/metrics/process/history_complexity.py
@@ -70,7 +70,9 @@ class HistoryComplexity(ProcessMetric):
             files[filepath] /= total_modifications
 
         # Normalized entropy
-        entropy = -sum(p*log(p+1/1e10, n_files) for p in files.values())
+        entropy = 0
+        if len(files.values()) > 1:
+            entropy = -sum(p*log(p+1/1e10, n_files) for p in files.values())
 
         for filepath in files:
             files[filepath] *= entropy

--- a/tests/metrics/process/test_history_complexity_count.py
+++ b/tests/metrics/process/test_history_complexity_count.py
@@ -6,7 +6,8 @@ from pydriller.metrics.process.history_complexity import HistoryComplexity
 
 TEST_DATA = [
     ('test-repos/pydriller', 'scm/git_repository.py', '90ca34ebfe69629cb7f186a1582fc38a73cc572e', '90ca34ebfe69629cb7f186a1582fc38a73cc572e', 40.49),
-    ('test-repos/pydriller', 'scm/git_repository.py', '71e053f61fc5d31b3e31eccd9c79df27c31279bf', '90ca34ebfe69629cb7f186a1582fc38a73cc572e', 47.05)
+    ('test-repos/pydriller', 'scm/git_repository.py', '71e053f61fc5d31b3e31eccd9c79df27c31279bf', '90ca34ebfe69629cb7f186a1582fc38a73cc572e', 47.05),
+    ('https://github.com/geerlingguy/ansible-role-solr', 'tasks/main.yml', '7fb350c30be1124b51aab4a88352428e0a853b9a', '678429591513fe86045e892a1da680c8ac36e00f', .0)
 ]
 
 @pytest.mark.parametrize('path_to_repo, filepath, from_commit, to_commit, expected', TEST_DATA)


### PR DESCRIPTION
When only one file was modified in the evolution period ```log(p+1/1e10, n_files)``` returned div-by-zero error.