### PR TITLE
Refactoring and using the 'single' filter when from_commit = to_commit 

### DIFF
--- a/pydriller/metrics/process/commits_count.py
+++ b/pydriller/metrics/process/commits_count.py
@@ -2,9 +2,8 @@
 Module that calculates the number of commits made to a file.
 """
 
-from pydriller import ModificationType, RepositoryMining
+from pydriller import ModificationType
 from pydriller.metrics.process.process_metric import ProcessMetric
-
 
 class CommitsCount(ProcessMetric):
     """
@@ -16,10 +15,8 @@ class CommitsCount(ProcessMetric):
         files = {}
         renamed_files = {}  # To keep track of renamed files
 
-        for commit in RepositoryMining(path_to_repo=self.path_to_repo,
-                                       from_commit=self.from_commit,
-                                       to_commit=self.to_commit,
-                                       reversed_order=True).traverse_commits():
+        for commit in self.repo_miner.traverse_commits():
+
             for modified_file in commit.modifications:
 
                 filepath = renamed_files.get(modified_file.new_path,

--- a/pydriller/metrics/process/contributors_count.py
+++ b/pydriller/metrics/process/contributors_count.py
@@ -4,7 +4,7 @@ modified file in the repo in a given time range.
 
 See https://dl.acm.org/doi/10.1145/2025113.2025119
 """
-from pydriller import ModificationType, RepositoryMining
+from pydriller import ModificationType
 from pydriller.metrics.process.process_metric import ProcessMetric
 
 
@@ -34,10 +34,7 @@ class ContributorsCount(ProcessMetric):
         renamed_files = {}
         files = {}
 
-        for commit in RepositoryMining(path_to_repo=self.path_to_repo,
-                                       from_commit=self.from_commit,
-                                       to_commit=self.to_commit,
-                                       reversed_order=True).traverse_commits():
+        for commit in self.repo_miner.traverse_commits():
 
             for modified_file in commit.modifications:
 

--- a/pydriller/metrics/process/contributors_experience.py
+++ b/pydriller/metrics/process/contributors_experience.py
@@ -1,7 +1,7 @@
 """
 Module that calculates the experience of contributors of a file.
 """
-from pydriller import ModificationType, RepositoryMining
+from pydriller import ModificationType
 from pydriller.metrics.process.process_metric import ProcessMetric
 
 
@@ -24,10 +24,7 @@ class ContributorsExperience(ProcessMetric):
         renamed_files = {}
         files = {}
 
-        for commit in RepositoryMining(path_to_repo=self.path_to_repo,
-                                       from_commit=self.from_commit,
-                                       to_commit=self.to_commit,
-                                       reversed_order=True).traverse_commits():
+        for commit in self.repo_miner.traverse_commits():
 
             for modified_file in commit.modifications:
 

--- a/pydriller/metrics/process/history_complexity.py
+++ b/pydriller/metrics/process/history_complexity.py
@@ -17,7 +17,7 @@ See https://ieeexplore.ieee.org/document/5070510
 """
 
 from math import log
-from pydriller import ModificationType, RepositoryMining
+from pydriller import ModificationType
 from pydriller.metrics.process.process_metric import ProcessMetric
 
 
@@ -43,10 +43,7 @@ class HistoryComplexity(ProcessMetric):
         renamed_files = {}
         files = {}
 
-        for commit in RepositoryMining(path_to_repo=self.path_to_repo,
-                                       from_commit=self.from_commit,
-                                       to_commit=self.to_commit,
-                                       reversed_order=True).traverse_commits():
+        for commit in self.repo_miner.traverse_commits():
 
             for modified_file in commit.modifications:
                 filepath = renamed_files.get(modified_file.new_path,

--- a/pydriller/metrics/process/hunks_count.py
+++ b/pydriller/metrics/process/hunks_count.py
@@ -3,7 +3,7 @@ Module that calculates the number of hunks made to a commit file.
 """
 from statistics import median
 
-from pydriller import ModificationType, RepositoryMining
+from pydriller import ModificationType
 from pydriller.metrics.process.process_metric import ProcessMetric
 
 
@@ -27,9 +27,7 @@ class HunksCount(ProcessMetric):
         renamed_files = {}
         files = {}
 
-        for commit in RepositoryMining(path_to_repo=self.path_to_repo,
-                                       from_commit=self.from_commit,
-                                       to_commit=self.to_commit).traverse_commits():
+        for commit in self.repo_miner.traverse_commits():
 
             for modified_file in commit.modifications:
 

--- a/pydriller/metrics/process/lines_count.py
+++ b/pydriller/metrics/process/lines_count.py
@@ -2,7 +2,7 @@
 Module that calculates the number of normalized added and deleted lines of a
 file.
 """
-from pydriller import ModificationType, RepositoryMining
+from pydriller import ModificationType
 from pydriller.metrics.process.process_metric import ProcessMetric
 
 
@@ -32,10 +32,7 @@ class LinesCount(ProcessMetric):
         renamed_files = {}
         files = {}
 
-        for commit in RepositoryMining(self.path_to_repo,
-                                       from_commit=self.from_commit,
-                                       to_commit=self.to_commit,
-                                       reversed_order=True).traverse_commits():
+        for commit in self.repo_miner.traverse_commits():
 
             for modified_file in commit.modifications:
 

--- a/pydriller/metrics/process/process_metric.py
+++ b/pydriller/metrics/process/process_metric.py
@@ -2,6 +2,7 @@
 This module contains the abstract class to implement process metrics.
 """
 
+from pydriller import RepositoryMining
 
 class ProcessMetric:
     """
@@ -21,9 +22,13 @@ class ProcessMetric:
         if not from_commit or not to_commit:
             raise TypeError
 
-        self.path_to_repo = path_to_repo
-        self.from_commit = from_commit
-        self.to_commit = to_commit
+        self.repo_miner = RepositoryMining(path_to_repo, single=from_commit)
+
+        if from_commit != to_commit:
+            self.repo_miner = RepositoryMining(path_to_repo=path_to_repo,
+                                               from_commit=from_commit,
+                                               to_commit=to_commit,
+                                               reversed_order=True)
 
     def count(self):
         """

--- a/pydriller/metrics/process/process_metric.py
+++ b/pydriller/metrics/process/process_metric.py
@@ -9,8 +9,8 @@ class ProcessMetric:
     """
 
     def __init__(self, path_to_repo: str,
-                 from_commit: str = None,
-                 to_commit: str = None):
+                 from_commit: str,
+                 to_commit: str):
         """
         :path_to_repo: path to a single repo
         :to_commit: the SHA of the commit to stop counting. If None, the

--- a/pydriller/metrics/process/process_metric.py
+++ b/pydriller/metrics/process/process_metric.py
@@ -18,6 +18,9 @@ class ProcessMetric:
         :from_commit: the SHA of the commit to start counting. If None, the
             analysis ends to the first commit
         """
+        if not from_commit or not to_commit:
+            raise TypeError
+
         self.path_to_repo = path_to_repo
         self.from_commit = from_commit
         self.to_commit = to_commit

--- a/tests/metrics/process/test_commits_count.py
+++ b/tests/metrics/process/test_commits_count.py
@@ -6,9 +6,7 @@ from pydriller.metrics.process.commits_count import CommitsCount
 
 TEST_DATA = [
     ('test-repos/pydriller', 'domain/developer.py', 'fdf671856b260aca058e6595a96a7a0fba05454b', 'ab36bf45859a210b0eae14e17683f31d19eea041', 2),
-    ('test-repos/pydriller', 'domain/developer.py', 'ab36bf45859a210b0eae14e17683f31d19eea041', 'fdf671856b260aca058e6595a96a7a0fba05454b', 2),
-    ('test-repos/pydriller', 'domain/developer.py', 'fdf671856b260aca058e6595a96a7a0fba05454b', None, 2),
-    ('test-repos/pydriller', 'pydriller/domain/developer.py', None, None, 8),
+    ('test-repos/pydriller', 'domain/developer.py', 'ab36bf45859a210b0eae14e17683f31d19eea041', 'fdf671856b260aca058e6595a96a7a0fba05454b', 2)
 ]
 
 

--- a/tests/metrics/process/test_contributors_count.py
+++ b/tests/metrics/process/test_contributors_count.py
@@ -6,8 +6,7 @@ from pydriller.metrics.process.contributors_count import ContributorsCount
 
 TEST_DATA = [
    ('test-repos/pydriller', 'pydriller/git_repository.py', '8b69cae085581256adfdbd58c0e499395819b84d', '115953109b57d841ccd0952d70f8ed6703d175cd', 2),
-   ('test-repos/pydriller', 'domain/modification.py', '71e053f61fc5d31b3e31eccd9c79df27c31279bf', None, 1),
-   ('test-repos/pydriller', 'pydriller/domain/developer.py', None, None, 1)
+   ('test-repos/pydriller', 'domain/modification.py', '71e053f61fc5d31b3e31eccd9c79df27c31279bf', 'ab36bf45859a210b0eae14e17683f31d19eea041', 1)
 ]
 
 @pytest.mark.parametrize('path_to_repo, filepath, from_commit, to_commit, expected', TEST_DATA)

--- a/tests/metrics/process/test_contributors_experience_count.py
+++ b/tests/metrics/process/test_contributors_experience_count.py
@@ -6,7 +6,7 @@ from pydriller.metrics.process.contributors_experience import \
     ContributorsExperience
 
 TEST_DATA = [
-   ('test-repos/pydriller', 'domain/modification.py', 'fdf671856b260aca058e6595a96a7a0fba05454b', None, 100.0),
+   ('test-repos/pydriller', 'domain/modification.py', 'fdf671856b260aca058e6595a96a7a0fba05454b', 'ab36bf45859a210b0eae14e17683f31d19eea041', 100.0),
    ('test-repos/pydriller', 'pydriller/git_repository.py', 'e9854bbea1cb7b7f06cbb559f7b06724d11ae1e5', 'e9854bbea1cb7b7f06cbb559f7b06724d11ae1e5', 100.0),
    ('test-repos/pydriller', 'pydriller/git_repository.py', 'e9854bbea1cb7b7f06cbb559f7b06724d11ae1e5', '9d0924301e4fae00eea6d00945bf834455e9a2a6', round(100*28/30, 2))
 ]

--- a/tests/metrics/process/test_hunks_count.py
+++ b/tests/metrics/process/test_hunks_count.py
@@ -6,8 +6,7 @@ from pydriller.metrics.process.hunks_count import HunksCount
 
 TEST_DATA = [
     ('test-repos/pydriller', 'scm/git_repository.py', '71e053f61fc5d31b3e31eccd9c79df27c31279bf', '71e053f61fc5d31b3e31eccd9c79df27c31279bf', 8),
-    ('test-repos/pydriller', 'scm/git_repository.py', None, '71e053f61fc5d31b3e31eccd9c79df27c31279bf', 3),
-    ('test-repos/pydriller', 'domain/modification.py', None, 'fdf671856b260aca058e6595a96a7a0fba05454b', 1),
+    ('test-repos/pydriller', 'scm/git_repository.py', 'ab36bf45859a210b0eae14e17683f31d19eea041', '71e053f61fc5d31b3e31eccd9c79df27c31279bf', 3),
     ('test-repos/pydriller', 'domain/modification.py', 'ab36bf45859a210b0eae14e17683f31d19eea041', 'fdf671856b260aca058e6595a96a7a0fba05454b', 1)
 ]
 

--- a/tests/metrics/process/test_lines_count.py
+++ b/tests/metrics/process/test_lines_count.py
@@ -5,14 +5,8 @@ import pytest
 from pydriller.metrics.process.lines_count import LinesCount
 
 TEST_DATA = [
-   ('test-repos/pydriller', '.gitignore', 'ab36bf45859a210b0eae14e17683f31d19eea041', None,
-      {'added': 197, 'removed': 0}),
-
    ('test-repos/pydriller', '.gitignore', 'ab36bf45859a210b0eae14e17683f31d19eea041', 'ab36bf45859a210b0eae14e17683f31d19eea041',
       {'added': 197, 'removed': 0}),
-
-   ('test-repos/pydriller', 'domain/modification.py', 'fdf671856b260aca058e6595a96a7a0fba05454b', None,
-      {'added': 49, 'removed': 1}),
 
    ('test-repos/pydriller', 'domain/modification.py', 'fdf671856b260aca058e6595a96a7a0fba05454b', 'ab36bf45859a210b0eae14e17683f31d19eea041',
       {'added': 49, 'removed': 1})

--- a/tests/metrics/process/test_minor_contributors_count.py
+++ b/tests/metrics/process/test_minor_contributors_count.py
@@ -6,8 +6,8 @@ from pydriller.metrics.process.contributors_count import ContributorsCount
 
 TEST_DATA = [
    ('test-repos/pydriller', 'pydriller/git_repository.py', 'e9854bbea1cb7b7f06cbb559f7b06724d11ae1e5', 'e9854bbea1cb7b7f06cbb559f7b06724d11ae1e5', 0),
-   ('test-repos/pydriller', 'pydriller/git_repository.py', 'e9854bbea1cb7b7f06cbb559f7b06724d11ae1e5', None, 1),
-   ('test-repos/pydriller', 'pydriller/git_repository.py', '4af3839eb5ea5969f42142529a7a5526739fa570', None, 2)
+   ('test-repos/pydriller', 'pydriller/git_repository.py', 'e9854bbea1cb7b7f06cbb559f7b06724d11ae1e5', 'ab36bf45859a210b0eae14e17683f31d19eea041', 1),
+   ('test-repos/pydriller', 'pydriller/git_repository.py', '4af3839eb5ea5969f42142529a7a5526739fa570', 'ab36bf45859a210b0eae14e17683f31d19eea041', 2)
 ]
 
 @pytest.mark.parametrize('path_to_repo, filepath, from_commit, to_commit, expected', TEST_DATA)


### PR DESCRIPTION
- Moved instantiation of RepositoryMining from method ```count()``` to ```ProcessMetric.__init__()``` for process metrics.

- Handle warning *"You should not point from_commit and to_commit to the same commit, but use the 'single' filter instead."* when ```from_commit = to_commit```.

If merged, closes https://github.com/ishepard/pydriller/pull/87