### PR TITLE
Using Git filters

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -45,7 +45,5 @@ jobs:
         if: matrix.os == 'ubuntu-latest' || matrix.os == 'macOS-latest'
         uses: codecov/codecov-action@v1
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml
           yml: .codecov.yml
-          fail_ci_if_error: true

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -46,4 +46,3 @@ jobs:
         uses: codecov/codecov-action@v1
         with:
           file: ./coverage.xml
-          yml: .codecov.yml

--- a/.pylintrc
+++ b/.pylintrc
@@ -244,7 +244,7 @@ indent-after-paren=4
 indent-string='    '
 
 # Maximum number of characters on a single line.
-max-line-length=79
+max-line-length=150
 
 # Maximum number of lines in a module.
 max-module-lines=1000

--- a/pydriller/git_repository.py
+++ b/pydriller/git_repository.py
@@ -121,16 +121,20 @@ class GitRepository:
         head_commit = self.repo.head.commit
         return Commit(head_commit, self._conf)
 
-    def get_list_commits(self, branch: str = None,
-                         reverse_order: bool = True) \
-            -> Generator[Commit, None, None]:
+    def get_list_commits(self, args: List = None) -> Generator[Commit, None, None]:
         """
         Return a generator of commits of all the commits in the repo.
 
         :return: Generator[Commit], the generator of all the commits in the
             repo
         """
-        for commit in self.repo.iter_commits(branch, reverse=reverse_order):
+        # With no arguments, just analyze all the commits until the HEAD,
+        # in reverse order
+        if args is None or not args:
+            args = [self.repo.head.commit.hexsha, '--reverse']
+
+        print(args)
+        for commit in self.repo.iter_commits(args):
             yield self.get_commit_from_gitpython(commit)
 
     def get_commit(self, commit_id: str) -> Commit:

--- a/pydriller/git_repository.py
+++ b/pydriller/git_repository.py
@@ -133,7 +133,6 @@ class GitRepository:
         if args is None or not args:
             args = [self.repo.head.commit.hexsha, '--reverse']
 
-        print(args)
         for commit in self.repo.iter_commits(args):
             yield self.get_commit_from_gitpython(commit)
 

--- a/pydriller/git_repository.py
+++ b/pydriller/git_repository.py
@@ -98,9 +98,7 @@ class GitRepository:
 
     def _open_repository(self):
         self._repo = Repo(str(self.path))
-        self._repo.config_writer().set_value("blame",
-                                             "markUnblamableLines",
-                                             "true").release()
+        self._repo.config_writer().set_value("blame", "markUnblamableLines", "true").release()
         if self._conf.get("main_branch") is None:
             self._discover_main_branch(self._repo)
 
@@ -108,8 +106,9 @@ class GitRepository:
         try:
             self._conf.set_value("main_branch", repo.active_branch.name)
         except TypeError:
-            logger.info("HEAD is a detached symbolic reference, setting "
-                        "main branch to empty string")
+            # The current HEAD is detached. In this case, it doesn't belong to
+            # any branch, hence we return an empty string
+            logger.info("HEAD is a detached symbolic reference, setting main branch to empty string")
             self._conf.set_value("main_branch", '')
 
     def get_head(self) -> Commit:
@@ -280,17 +279,15 @@ class GitRepository:
 
         for mod in modifications:
             path = mod.new_path
-            if mod.change_type == ModificationType.RENAME or \
-                    mod.change_type == ModificationType.DELETE:
+            if mod.change_type == ModificationType.RENAME or mod.change_type == ModificationType.DELETE:
                 path = mod.old_path
             deleted_lines = mod.diff_parsed['deleted']
+
             try:
-                blame = self._get_blame(commit.hash, path,
-                                        hashes_to_ignore_path)
+                blame = self._get_blame(commit.hash, path, hashes_to_ignore_path)
                 for num_line, line in deleted_lines:
                     if not self._useless_line(line.strip()):
-                        buggy_commit = blame[num_line - 1].split(' ')[
-                            0].replace('^', '')
+                        buggy_commit = blame[num_line - 1].split(' ')[0].replace('^', '')
 
                         # Skip unblamable lines.
                         if buggy_commit.startswith("*"):
@@ -299,8 +296,7 @@ class GitRepository:
                         if mod.change_type == ModificationType.RENAME:
                             path = mod.new_path
 
-                        commits.setdefault(path, set()).add(
-                            self.get_commit(buggy_commit).hash)
+                        commits.setdefault(path, set()).add(self.get_commit(buggy_commit).hash)
             except GitCommandError:
                 logger.debug(
                     "Could not found file %s in commit %s. Probably a double "
@@ -308,15 +304,13 @@ class GitRepository:
 
         return commits
 
-    def _get_blame(self, commit_hash: str, path: str,
-                   hashes_to_ignore_path: List[str] = None):
+    def _get_blame(self, commit_hash: str, path: str, hashes_to_ignore_path: List[str] = None):
         args = ['-w', commit_hash + '^']
         if hashes_to_ignore_path is not None:
             if self.git.version_info >= (2, 23):
                 args += ["--ignore-revs-file", hashes_to_ignore_path]
             else:
-                logger.info("'--ignore-revs-file' is only available from "
-                            "git v2.23")
+                logger.info("'--ignore-revs-file' is only available from git v2.23")
         return self.git.blame(*args, '--', path).split('\n')
 
     @staticmethod

--- a/pydriller/git_repository.py
+++ b/pydriller/git_repository.py
@@ -121,19 +121,18 @@ class GitRepository:
         head_commit = self.repo.head.commit
         return Commit(head_commit, self._conf)
 
-    def get_list_commits(self, args: List = None) -> Generator[Commit, None, None]:
+    def get_list_commits(self, rev='HEAD', **kwargs) -> Generator[Commit, None, None]:
         """
         Return a generator of commits of all the commits in the repo.
 
         :return: Generator[Commit], the generator of all the commits in the
             repo
         """
-        # With no arguments, just analyze all the commits until the HEAD,
-        # in reverse order
-        if args is None or not args:
-            args = [self.repo.head.commit.hexsha, '--reverse']
+        # If not specified otherwise, analyze the repository in reversed order
+        if 'reverse' not in kwargs:
+            kwargs['reverse'] = True
 
-        for commit in self.repo.iter_commits(args):
+        for commit in self.repo.iter_commits(rev=rev, **kwargs):
             yield self.get_commit_from_gitpython(commit)
 
     def get_commit(self, commit_id: str) -> Commit:

--- a/pydriller/metrics/process/history_complexity.py
+++ b/pydriller/metrics/process/history_complexity.py
@@ -17,6 +17,7 @@ See https://ieeexplore.ieee.org/document/5070510
 """
 
 from math import log
+
 from pydriller import ModificationType
 from pydriller.metrics.process.process_metric import ProcessMetric
 

--- a/pydriller/repository_mining.py
+++ b/pydriller/repository_mining.py
@@ -155,14 +155,20 @@ class RepositoryMining:
 
             logger.info('Analyzing git repository in %s', git_repo.path)
 
+            # Get the commits that modified the filepath. In this case, we can not use
+            # git rev-list since it doesn't have the option --follow, necessary to follow
+            # the renames. Hence, we manually call git log instead
             if self._conf.get('filepath') is not None:
                 self._conf.set_value('filepath_commits', git_repo.get_commits_modified_file(self._conf.get('filepath')))
 
+            # Gets only the commits that are tagged
             if self._conf.get('only_releases'):
                 self._conf.set_value('tagged_commits', git_repo.get_tagged_commits())
 
+            # Build the arguments to pass to git rev-list.
             rev, kwargs = self._conf.build_args()
 
+            # Iterate over all the commits returned by git rev-list
             for commit in git_repo.get_list_commits(rev, **kwargs):
                 logger.info('Commit #%s in %s from %s', commit.hash, commit.committer_date, commit.author.name)
 
@@ -172,7 +178,7 @@ class RepositoryMining:
 
                 yield commit
 
-            # cleaning
+            # cleaning, this is necessary since GitPython issues on memory leaks
             self._conf.set_value("git_repo", None)
             git_repo.clear()
 

--- a/pydriller/repository_mining.py
+++ b/pydriller/repository_mining.py
@@ -139,14 +139,11 @@ class RepositoryMining:
                 if self._conf.get('clone_repo_to'):
                     clone_folder = str(Path(self._conf.get('clone_repo_to')))
                     if not os.path.isdir(clone_folder):
-                        raise Exception("Not a directory: " \
-                                        "{0}".format(clone_folder))
-                    path_repo = self._clone_remote_repos(clone_folder,
-                                                         path_repo)
+                        raise Exception("Not a directory: {0}".format(clone_folder))
+                    path_repo = self._clone_remote_repos(clone_folder, path_repo)
                 else:
                     tmp_folder = tempfile.TemporaryDirectory()
-                    path_repo = self._clone_remote_repos(tmp_folder.name,
-                                                         path_repo)
+                    path_repo = self._clone_remote_repos(tmp_folder.name, path_repo)
 
             git_repo = GitRepository(path_repo, self._conf)
             self._conf.set_value("git_repo", git_repo)
@@ -155,19 +152,15 @@ class RepositoryMining:
             logger.info('Analyzing git repository in %s', git_repo.path)
 
             if self._conf.get('filepath') is not None:
-                self._conf.set_value('filepath_commits',
-                                     git_repo.get_commits_modified_file(
-                                         self._conf.get('filepath')))
+                self._conf.set_value('filepath_commits', git_repo.get_commits_modified_file(self._conf.get('filepath')))
 
             if self._conf.get('only_releases'):
-                self._conf.set_value('tagged_commits',
-                                     git_repo.get_tagged_commits())
+                self._conf.set_value('tagged_commits', git_repo.get_tagged_commits())
 
-            for commit in git_repo.get_list_commits(self._conf.get(
-                    'only_in_branch'), not self._conf.get('reversed_order')):
-                logger.info('Commit #%s in %s from %s', commit.hash,
-                            commit.committer_date,
-                            commit.author.name)
+            args = self._conf.build_args()
+
+            for commit in git_repo.get_list_commits(args):
+                logger.info('Commit #%s in %s from %s', commit.hash, commit.committer_date, commit.author.name)
 
                 if self._conf.is_commit_filtered(commit):
                     logger.info('Commit #%s filtered', commit.hash)

--- a/pydriller/repository_mining.py
+++ b/pydriller/repository_mining.py
@@ -21,7 +21,7 @@ import os
 import tempfile
 from datetime import datetime
 from pathlib import Path
-from typing import List, Generator, Union, Set
+from typing import List, Generator, Union
 
 from git import Repo
 

--- a/pydriller/repository_mining.py
+++ b/pydriller/repository_mining.py
@@ -21,7 +21,7 @@ import os
 import tempfile
 from datetime import datetime
 from pathlib import Path
-from typing import List, Generator, Union
+from typing import List, Generator, Union, Set
 
 from git import Repo
 
@@ -88,6 +88,11 @@ class RepositoryMining:
         :param str filepath: only commits that modified this file will be
             analyzed
         """
+        if only_modifications_with_file_types is not None:
+            only_modifications_with_file_types = set(only_modifications_with_file_types)
+        if only_commits is not None:
+            only_commits = set(only_commits)
+
         options = {
             "git_repo": None,
             "path_to_repo": path_to_repo,
@@ -100,8 +105,7 @@ class RepositoryMining:
             "single": single,
             "reversed_order": reversed_order,
             "only_in_branch": only_in_branch,
-            "only_modifications_with_file_types":
-                only_modifications_with_file_types,
+            "only_modifications_with_file_types": only_modifications_with_file_types,
             "only_no_merge": only_no_merge,
             "only_authors": only_authors,
             "only_commits": only_commits,
@@ -157,9 +161,9 @@ class RepositoryMining:
             if self._conf.get('only_releases'):
                 self._conf.set_value('tagged_commits', git_repo.get_tagged_commits())
 
-            args = self._conf.build_args()
+            rev, kwargs = self._conf.build_args()
 
-            for commit in git_repo.get_list_commits(args):
+            for commit in git_repo.get_list_commits(rev, **kwargs):
                 logger.info('Commit #%s in %s from %s', commit.hash, commit.committer_date, commit.author.name)
 
                 if self._conf.is_commit_filtered(commit):

--- a/pydriller/utils/conf.py
+++ b/pydriller/utils/conf.py
@@ -186,6 +186,8 @@ class Conf:
 
     def build_args(self):
         single = self.get('single')
+        since = self.get('since')
+        until = self.get('to')
         from_commit = self.get('from_commit')
         to_commit = self.get('to_commit')
         branch = self.get('only_in_branch')
@@ -220,6 +222,12 @@ class Conf:
         if authors is not None:
             kwargs['author'] = authors
 
+        if since is not None:
+            kwargs['since'] = since
+
+        if until is not None:
+            kwargs['until'] = until
+
         return rev, kwargs
 
     def is_commit_filtered(self, commit: Commit):
@@ -231,11 +239,6 @@ class Conf:
         :param Commit commit: Commit to check
         :return:
         """
-        if (self.get('since') is not None and
-            commit.committer_date < self.get('since')) or \
-                (self.get('to') is not None and
-                 commit.committer_date > self.get('to')):
-            return True
         if self.get('only_modifications_with_file_types') is not None:
             if not self._has_modification_with_file_type(commit):
                 logger.debug('Commit filtered for modification types')

--- a/pydriller/utils/conf.py
+++ b/pydriller/utils/conf.py
@@ -212,7 +212,6 @@ class Conf:
         if not self.get('reversed_order'):
             args.append('--reverse')
 
-        print(f'Returning args: {args}')
         return args
 
     def is_commit_filtered(self, commit: Commit):

--- a/pydriller/utils/conf.py
+++ b/pydriller/utils/conf.py
@@ -185,6 +185,7 @@ class Conf:
         return len([x for x in arr if x is not None]) <= 1
 
     def build_args(self):
+        single = self.get('single')
         from_commit = self.get('from_commit')
         to_commit = self.get('to_commit')
         branch = self.get('only_in_branch')
@@ -192,7 +193,9 @@ class Conf:
         rev = []
         kwargs = {}
 
-        if from_commit is not None or to_commit is not None:
+        if single is not None:
+            rev = [single, '-n', 1]
+        elif from_commit is not None or to_commit is not None:
             if from_commit is not None and to_commit is not None:
                 rev.extend(from_commit)
                 rev.append(to_commit)
@@ -228,11 +231,6 @@ class Conf:
         :param Commit commit: Commit to check
         :return:
         """
-        if self.get('single') is not None and \
-                commit.hash != self.get('single'):
-            logger.debug('Commit filtered because is not '
-                         'the defined in single')
-            return True
         if (self.get('since') is not None and
             commit.committer_date < self.get('since')) or \
                 (self.get('to') is not None and

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 gitpython
-typing; python_version < '3.5'
 pytz
 lizard

--- a/tests/integration/test_commit_filters.py
+++ b/tests/integration/test_commit_filters.py
@@ -14,19 +14,17 @@
 
 import logging
 from datetime import datetime, timezone, timedelta
+from pydriller.repository_mining import RepositoryMining
 
 import pytest
 
 logging.basicConfig(format='%(asctime)s - %(levelname)s - %(message)s',
                     level=logging.INFO)
 
-from pydriller.repository_mining import RepositoryMining
-
 
 def test_mod_with_file_types():
     lc = list(RepositoryMining('test-repos/different_files',
-                               only_modifications_with_file_types=['.java'])
-              .traverse_commits())
+                               only_modifications_with_file_types=['.java']).traverse_commits())
 
     assert len(lc) == 2
     assert lc[0].hash == 'a1b6136f978644ff1d89816bc0f2bd86f6d9d7f5'
@@ -190,8 +188,7 @@ def test_single_commit_head():
                                single="e7d13b0511f8a176284ce4f92ed8c6e8d09c77f2").traverse_commits())
     assert len(lc) == 1
 
-    lc_head = list(RepositoryMining('test-repos/complex_repo',
-                               single="HEAD").traverse_commits())
+    lc_head = list(RepositoryMining('test-repos/complex_repo', single="HEAD").traverse_commits())
     assert len(lc_head) == 1
     assert lc[0].hash == lc_head[0].hash
 
@@ -278,7 +275,6 @@ def test_only_releases():
 
 
 def test_only_releases_wo_releases():
-    lc = list(RepositoryMining('test-repos/complex_repo',
-                               only_releases=True).traverse_commits())
+    lc = list(RepositoryMining('test-repos/complex_repo', only_releases=True).traverse_commits())
 
     assert len(lc) == 0

--- a/tests/integration/test_ranges.py
+++ b/tests/integration/test_ranges.py
@@ -22,8 +22,8 @@ from datetime import datetime, timezone, timedelta
 
 to_zone = timezone(timedelta(hours=1))
 dt = datetime(2018, 3, 22, 10, 41, 30, tzinfo=to_zone)
-dt1 = datetime(2018, 3, 22, 10, 42, 3, tzinfo=to_zone)
-dt2 = datetime(2018, 3, 22, 10, 41, 45, tzinfo=to_zone)
+dt1 = datetime(2018, 3, 22, 10, 41, 45, tzinfo=to_zone)
+dt2 = datetime(2018, 3, 22, 10, 42, 3, tzinfo=to_zone)
 to_zone = timezone(timedelta(hours=2))
 dt3 = datetime(2018, 3, 27, 17, 20, 3, tzinfo=to_zone)
 
@@ -77,6 +77,7 @@ def repository_mining_cc(path, from_commit, to_commit):
 def repository_mining_tt(path, from_tag, to_tag):
     return list(RepositoryMining(path, from_tag=from_tag, to_tag=to_tag).traverse_commits())
 
+
 @pytest.fixture
 def repository_mining_complex_tags(path, from_tag, to_tag):
     return list(RepositoryMining('test-repos/tags',
@@ -86,7 +87,10 @@ def repository_mining_complex_tags(path, from_tag, to_tag):
 
 @pytest.mark.parametrize('to,expected_commits', [
     (None, 5),
-    (dt1, 3),
+    (dt, 1),
+    (dt1, 1),
+    (dt2, 3),
+    (dt3, 4),
 ])
 def test_to_filter(repository_mining_st, expected_commits):
     assert len(repository_mining_st) == expected_commits
@@ -95,13 +99,18 @@ def test_to_filter(repository_mining_st, expected_commits):
 @pytest.mark.parametrize('since,expected_commits', [
     (None, 5),
     (dt, 4),
+    (dt1, 4),
+    (dt2, 3),
+    (dt3, 1),
 ])
 def test_since_filter(repository_mining_st, expected_commits):
     assert len(repository_mining_st) == expected_commits
 
 
 @pytest.mark.parametrize('since,to,expected_commits', [
-    (dt2, dt3, 3),
+    (dt1, dt3, 3),
+    (dt, dt3, 3),
+    (dt2, dt3, 2),
 ])
 def test_since_and_to_filters(repository_mining_st, expected_commits):
     assert len(repository_mining_st) == expected_commits
@@ -175,14 +184,14 @@ def test_multiple_filters_exceptions():
 
     with pytest.raises(Exception):
         for commit in RepositoryMining('test-repos/small_repo/',
-                                       since=dt2,
+                                       since=dt1,
                                        from_commit=from_commit
                                        ).traverse_commits():
             print(commit.hash)
 
     with pytest.raises(Exception):
         for commit in RepositoryMining('test-repos/small_repo/',
-                                       since=dt2,
+                                       since=dt1,
                                        from_tag=from_tag).traverse_commits():
             print(commit.hash)
 
@@ -194,20 +203,20 @@ def test_multiple_filters_exceptions():
 
     with pytest.raises(Exception):
         for commit in RepositoryMining('test-repos/small_repo/',
-                                       to=dt2,
+                                       to=dt1,
                                        to_commit=from_commit
                                        ).traverse_commits():
             print(commit.hash)
 
     with pytest.raises(Exception):
         for commit in RepositoryMining('test-repos/small_repo/',
-                                       to=dt2,
+                                       to=dt1,
                                        to_tag=from_tag).traverse_commits():
             print(commit.hash)
 
     with pytest.raises(Exception):
         for commit in RepositoryMining('test-repos/small_repo/',
                                        single=from_commit,
-                                       to=dt2,
+                                       to=dt1,
                                        to_tag=from_tag).traverse_commits():
             print(commit.hash)

--- a/tests/integration/test_ranges.py
+++ b/tests/integration/test_ranges.py
@@ -138,6 +138,13 @@ def test_from_and_to_commit(repository_mining_cc, expected_commits):
     assert len(repository_mining_cc) == expected_commits
 
 
+def test_from_and_to_commit_with_merge_commit():
+    commits = RepositoryMining('test-repos/pydriller',
+                               from_commit="015f7144641a418f6a9fae4d024286ec17fd7ce8",
+                               to_commit="01d2f2fbeb6980cc5568825d008017ca8ca767d6").traverse_commits()
+    assert len(list(commits)) == 3
+
+
 # FROM AND TO TAG
 @pytest.mark.parametrize('to_tag,expected_commits', [
     ('v1.4', 3),

--- a/tests/test_git_repository.py
+++ b/tests/test_git_repository.py
@@ -51,11 +51,11 @@ def test_get_head(repo):
 def test_list_commits(repo):
     change_sets = list(repo.get_list_commits())
 
-    list_commits = ['a88c84ddf42066611e76e6cb690144e5357d132c',
+    list_commits = {'a88c84ddf42066611e76e6cb690144e5357d132c',
                     '6411e3096dd2070438a17b225f44475136e54e3a',
                     '09f6182cef737db02a085e1d018963c7a29bde5a',
                     '1f99848edadfffa903b8ba1286a935f1b92b2845',
-                    'da39b1326dbc2edfe518b90672734a08f3c13458']
+                    'da39b1326dbc2edfe518b90672734a08f3c13458'}
 
     for commit in change_sets:
         assert commit.hash in list_commits

--- a/tests/test_memory_consumption.py
+++ b/tests/test_memory_consumption.py
@@ -58,7 +58,7 @@ def test_memory(caplog):
         diff_with_nothing.seconds // 3600,
         (diff_with_nothing.seconds % 3600) // 60,
         diff_with_nothing.seconds % 60,
-        973 // diff_with_nothing.seconds,
+        973 // diff_with_nothing.seconds if diff_with_nothing.seconds != 0 else 0,
         diff_with_everything.seconds // 3600,
         (diff_with_everything.seconds % 3600) // 60,
         diff_with_everything.seconds % 60,

--- a/tests/test_repository_mining.py
+++ b/tests/test_repository_mining.py
@@ -228,3 +228,9 @@ def test_clone_repo_to(tmp_path):
         path_to_repo=url,
         to=dt2,
         clone_repo_to=str(tmp_path)).traverse_commits())) == 159
+
+
+def test_clone_repo_to_not_existing():
+    with pytest.raises(Exception):
+        list(RepositoryMining("https://github.com/ishepard/pydriller",
+                              clone_repo_to="NOTEXISTINGDIR").traverse_commits())


### PR DESCRIPTION
Git has many filters to filter commits (see [doc](https://git-scm.com/docs/git-rev-list)). 

So far, Pydriller was using a naive technique, such as get **all** the commits and then check the filters provided by the users to filter out the ones that the user doesn't want.

However, this has become quite a problem now: it's not scalable, sometimes it produces wrong results, it's quite slow, etc.

So with this PR, I will start to adopt Git filters instead. 

Fix #93, #94, and many others in the future