### PR TITLE
Added process metric to measure the number of files committed together

### DIFF
--- a/pydriller/metrics/process/change_set.py
+++ b/pydriller/metrics/process/change_set.py
@@ -1,0 +1,45 @@
+"""
+Module that calculates the number of files committed together.
+"""
+import statistics
+
+from pydriller.metrics.process.process_metric import ProcessMetric
+
+class ChangeSet(ProcessMetric):
+    """
+    This class is responsible to implement the Change Set metric that
+    measures the
+
+    * maximum number of files committed together - max();
+    * average number of files committed together - avg().
+    """
+
+    def __init__(self, path_to_repo: str,
+                 from_commit: str,
+                 to_commit: str):
+        super().__init__(path_to_repo, from_commit, to_commit)
+        self.__initialize()
+
+    def __initialize(self):
+
+        self.committed_together = []
+
+        for commit in self.repo_miner.traverse_commits():
+            self.committed_together.append(len(commit.modifications))
+
+    def max(self):
+        """
+        Return the maximum number of files committed together.
+
+        :return: int max number of files committed together
+        """
+        return max(self.committed_together)
+
+    def avg(self):
+        """
+        Return the average number of files committed together.
+
+        :return: int avg number of files rounded off to the nearest integer
+        """
+
+        return round(statistics.mean(self.committed_together))

--- a/tests/metrics/process/test_change_set.py
+++ b/tests/metrics/process/test_change_set.py
@@ -1,0 +1,18 @@
+import pytest
+from pydriller.metrics.process.change_set import ChangeSet
+
+TEST_DATA = [
+    ('test-repos/pydriller', 'ab36bf45859a210b0eae14e17683f31d19eea041', '71e053f61fc5d31b3e31eccd9c79df27c31279bf', 13, 8)
+]
+
+@pytest.mark.parametrize('path_to_repo, from_commit, to_commit, expected_max, expected_avg', TEST_DATA)
+def test(path_to_repo, from_commit, to_commit, expected_max, expected_avg):
+    metric = ChangeSet(path_to_repo=path_to_repo,
+                       from_commit=from_commit,
+                       to_commit=to_commit)
+
+    actual_max = metric.max()
+    actual_avg = metric.avg()
+
+    assert actual_max == expected_max
+    assert actual_avg == expected_avg


### PR DESCRIPTION
Metrics from paper [A Comparative Analysis of the Efficiency of Change Metrics and Static Code Attributes for Defect Prediction](https://dl.acm.org/doi/pdf/10.1145/1368088.1368114).

## ChangeSet
Added:

* ```max()``` - the maximum number of files committed together in the period ```[from_commit, to_commit]```

* ```avg()``` - the average number of files committed together in the period ```[from_commit, to_commit]```
