### PR TITLE
Update LinesCount to measure count, max, and average number of added/…

### DIFF
--- a/tests/metrics/process/test_lines_added.py
+++ b/tests/metrics/process/test_lines_added.py
@@ -1,0 +1,24 @@
+import pytest
+from pathlib import Path
+from pydriller.metrics.process.lines_count import LinesCount
+
+TEST_DATA = [
+   ('test-repos/pydriller', '.gitignore', 'ab36bf45859a210b0eae14e17683f31d19eea041', 'ab36bf45859a210b0eae14e17683f31d19eea041', 197, 197, 197),
+   ('test-repos/pydriller', 'domain/modification.py', 'ab36bf45859a210b0eae14e17683f31d19eea041', '71e053f61fc5d31b3e31eccd9c79df27c31279bf', 61, 48, 20)
+]
+
+@pytest.mark.parametrize('path_to_repo, filepath, from_commit, to_commit, expected_count, expected_max, expected_avg', TEST_DATA)
+def test(path_to_repo, filepath, from_commit, to_commit, expected_count, expected_max, expected_avg):
+    metric = LinesCount(path_to_repo=path_to_repo,
+                        from_commit=from_commit,
+                        to_commit=to_commit)
+
+    actual_count = metric.count_added()
+    actual_max = metric.max_added()
+    actual_avg = metric.avg_added()
+
+    filepath = str(Path(filepath))
+
+    assert actual_count[filepath] == expected_count
+    assert actual_max[filepath] == expected_max
+    assert actual_avg[filepath] == expected_avg

--- a/tests/metrics/process/test_lines_count.py
+++ b/tests/metrics/process/test_lines_count.py
@@ -1,23 +1,19 @@
-from pathlib import Path
-
 import pytest
-
+from pathlib import Path
 from pydriller.metrics.process.lines_count import LinesCount
 
 TEST_DATA = [
-   ('test-repos/pydriller', '.gitignore', 'ab36bf45859a210b0eae14e17683f31d19eea041', 'ab36bf45859a210b0eae14e17683f31d19eea041',
-      {'added': 197, 'removed': 0}),
-
-   ('test-repos/pydriller', 'domain/modification.py', 'fdf671856b260aca058e6595a96a7a0fba05454b', 'ab36bf45859a210b0eae14e17683f31d19eea041',
-      {'added': 49, 'removed': 1})
+   ('test-repos/pydriller', '.gitignore', 'ab36bf45859a210b0eae14e17683f31d19eea041', 'ab36bf45859a210b0eae14e17683f31d19eea041', 197),
+   ('test-repos/pydriller', 'domain/modification.py', 'ab36bf45859a210b0eae14e17683f31d19eea041', '71e053f61fc5d31b3e31eccd9c79df27c31279bf', 65)
 ]
 
-@pytest.mark.parametrize('path_to_repo, filepath, from_commit, to_commit, expected', TEST_DATA)
-def test(path_to_repo, filepath, from_commit, to_commit, expected):
+@pytest.mark.parametrize('path_to_repo, filepath, from_commit, to_commit, expected_count', TEST_DATA)
+def test(path_to_repo, filepath, from_commit, to_commit, expected_count):
     metric = LinesCount(path_to_repo=path_to_repo,
                         from_commit=from_commit,
                         to_commit=to_commit)
 
-    count = metric.count()
+    actual_count = metric.count()
     filepath = str(Path(filepath))
-    assert count[filepath] == expected
+
+    assert actual_count[filepath] == expected_count

--- a/tests/metrics/process/test_lines_removed.py
+++ b/tests/metrics/process/test_lines_removed.py
@@ -1,0 +1,24 @@
+import pytest
+from pathlib import Path
+from pydriller.metrics.process.lines_count import LinesCount
+
+TEST_DATA = [
+   ('test-repos/pydriller', '.gitignore', 'ab36bf45859a210b0eae14e17683f31d19eea041', 'ab36bf45859a210b0eae14e17683f31d19eea041', 0, 0, 0),
+   ('test-repos/pydriller', 'domain/modification.py', 'ab36bf45859a210b0eae14e17683f31d19eea041', '71e053f61fc5d31b3e31eccd9c79df27c31279bf', 4, 3, 1)
+]
+
+@pytest.mark.parametrize('path_to_repo, filepath, from_commit, to_commit, expected_count, expected_max, expected_avg', TEST_DATA)
+def test(path_to_repo, filepath, from_commit, to_commit, expected_count, expected_max, expected_avg):
+    metric = LinesCount(path_to_repo=path_to_repo,
+                        from_commit=from_commit,
+                        to_commit=to_commit)
+
+    actual_count = metric.count_removed()
+    actual_max = metric.max_removed()
+    actual_avg = metric.avg_removed()
+
+    filepath = str(Path(filepath))
+
+    assert actual_count[filepath] == expected_count
+    assert actual_max[filepath] == expected_max
+    assert actual_avg[filepath] == expected_avg


### PR DESCRIPTION
…removed lines to a file.

Metrics from paper [A Comparative Analysis of the Efficiency of Change Metrics and Static Code Attributes for Defect Prediction](https://dl.acm.org/doi/pdf/10.1145/1368088.1368114).

## LinesCount

Modified:

* ```count``` - Now return the sum added + removed lines for each modified file in the period ```[from_commit, to_commit]```.

Added:

* ```count_added()``` - the total number of lines added to a file in the period ```[from_commit, to_commit]```

* ```max_added()``` -  the maximum number of lines added to a file in the period ```[from_commit, to_commit]```

* ```avg_added()``` -  the average number of lines added to a file in the period ```[from_commit, to_commit]```

* ```count_removed()``` - the total number of lines removed to a file in the period ```[from_commit, to_commit]```

* ```max_removed()``` -  the maximum number of lines removed to a file in the period ```[from_commit, to_commit]```

* ```avg_removed()``` -  the average number of lines removed to a file in the period ```[from_commit, to_commit]```
