### PR TITLE
Now process metrics support datetime  

### DIFF
--- a/docs/processmetrics.rst
+++ b/docs/processmetrics.rst
@@ -7,6 +7,8 @@ Process Metrics
 Process metrics capture aspects of the development process rather than aspects about the code itself.
 From release 1.11 PyDriller can calculate ``change_set``, ``code churn``, ``commits count``, ``contributors count``, ``contributors experience``, ``history complexity``, ``hunks count``, ``lines count`` and ``minor contributors``. Everything in just one line!
 
+The metrics can be run between two commits (setting up the parameters ``from_commit`` and ``to_commit``) or between two dates (setting up the parameters ``since`` and ``to``)
+
 Below an example of how call the metrics.
 
 
@@ -35,6 +37,22 @@ For example::
 will print the maximum and average number of files committed together in the evolution period ``[from_commit, to_commit]``. 
 
 **Note:** differently from the other metrics below, the scope of this metrics is the evolution period rather than the single files.
+
+
+It is possible to specify the dates as follows::
+
+    from datetime import datetime
+    from pydriller.metrics.process.change_set import ChangeSet
+    metric = ChangeSet(path_to_repo='path/to/the/repo',
+                       since=datetime(2019, 1, 1),
+                       to=datetime(2019, 12, 31))
+    
+    maximum = metric.max()
+    average = metric.avg()
+    print('Maximum number of files committed together: {}'.format(maximum))
+    print('Average number of files committed together: {}'.format(average))
+
+The code above will print the maximum and average number of files committed together between the ``1st January 2019`` and ``31st December 2019``. 
 
 
 Code Churn

--- a/pydriller/metrics/process/change_set.py
+++ b/pydriller/metrics/process/change_set.py
@@ -17,7 +17,8 @@ class ChangeSet(ProcessMetric):
     def __init__(self, path_to_repo: str,
                  from_commit: str,
                  to_commit: str):
-        super().__init__(path_to_repo, from_commit, to_commit)
+
+        super().__init__(path_to_repo, from_commit=from_commit, to_commit=to_commit)
         self._initialize()
 
     def _initialize(self):

--- a/pydriller/metrics/process/change_set.py
+++ b/pydriller/metrics/process/change_set.py
@@ -15,10 +15,12 @@ class ChangeSet(ProcessMetric):
     """
 
     def __init__(self, path_to_repo: str,
-                 from_commit: str,
-                 to_commit: str):
+                 since = None,
+                 to = None,
+                 from_commit: str = None,
+                 to_commit: str = None):
 
-        super().__init__(path_to_repo, from_commit=from_commit, to_commit=to_commit)
+        super().__init__(path_to_repo, since=since, to=to, from_commit=from_commit, to_commit=to_commit)
         self._initialize()
 
     def _initialize(self):

--- a/pydriller/metrics/process/code_churn.py
+++ b/pydriller/metrics/process/code_churn.py
@@ -21,7 +21,8 @@ class CodeChurn(ProcessMetric):
     def __init__(self, path_to_repo: str,
                  from_commit: str,
                  to_commit: str):
-        super().__init__(path_to_repo, from_commit, to_commit)
+
+        super().__init__(path_to_repo, from_commit=from_commit, to_commit=to_commit)
         self._initialize()
 
     def _initialize(self):

--- a/pydriller/metrics/process/code_churn.py
+++ b/pydriller/metrics/process/code_churn.py
@@ -19,10 +19,12 @@ class CodeChurn(ProcessMetric):
     """
 
     def __init__(self, path_to_repo: str,
-                 from_commit: str,
-                 to_commit: str):
+                 since = None,
+                 to = None,
+                 from_commit: str = None,
+                 to_commit: str = None):
 
-        super().__init__(path_to_repo, from_commit=from_commit, to_commit=to_commit)
+        super().__init__(path_to_repo, since=since, to=to, from_commit=from_commit, to_commit=to_commit)
         self._initialize()
 
     def _initialize(self):

--- a/pydriller/metrics/process/contributors_count.py
+++ b/pydriller/metrics/process/contributors_count.py
@@ -20,10 +20,12 @@ class ContributorsCount(ProcessMetric):
     """
 
     def __init__(self, path_to_repo: str,
-                 from_commit: str,
-                 to_commit: str):
+                 since = None,
+                 to = None,
+                 from_commit: str = None,
+                 to_commit: str = None):
 
-        super().__init__(path_to_repo, from_commit=from_commit, to_commit=to_commit)
+        super().__init__(path_to_repo, since=since, to=to, from_commit=from_commit, to_commit=to_commit)
         self._initialize()
 
     def _initialize(self):

--- a/pydriller/metrics/process/contributors_count.py
+++ b/pydriller/metrics/process/contributors_count.py
@@ -22,7 +22,8 @@ class ContributorsCount(ProcessMetric):
     def __init__(self, path_to_repo: str,
                  from_commit: str,
                  to_commit: str):
-        super().__init__(path_to_repo, from_commit, to_commit)
+
+        super().__init__(path_to_repo, from_commit=from_commit, to_commit=to_commit)
         self._initialize()
 
     def _initialize(self):

--- a/pydriller/metrics/process/lines_count.py
+++ b/pydriller/metrics/process/lines_count.py
@@ -34,10 +34,12 @@ class LinesCount(ProcessMetric):
     """
 
     def __init__(self, path_to_repo: str,
-                 from_commit: str,
-                 to_commit: str):
+                 since = None,
+                 to = None,
+                 from_commit: str = None,
+                 to_commit: str = None):
 
-        super().__init__(path_to_repo, from_commit=from_commit, to_commit=to_commit)
+        super().__init__(path_to_repo, since=since, to=to, from_commit=from_commit, to_commit=to_commit)
         self._initialize()
 
     def _initialize(self):

--- a/pydriller/metrics/process/lines_count.py
+++ b/pydriller/metrics/process/lines_count.py
@@ -36,7 +36,8 @@ class LinesCount(ProcessMetric):
     def __init__(self, path_to_repo: str,
                  from_commit: str,
                  to_commit: str):
-        super().__init__(path_to_repo, from_commit, to_commit)
+
+        super().__init__(path_to_repo, from_commit=from_commit, to_commit=to_commit)
         self._initialize()
 
     def _initialize(self):

--- a/pydriller/metrics/process/process_metric.py
+++ b/pydriller/metrics/process/process_metric.py
@@ -33,10 +33,13 @@ class ProcessMetric:
         if not to and not to_commit:
             raise TypeError('You must pass one between to and to_commit')
 
-        self.repo_miner = RepositoryMining(path_to_repo, single=from_commit)
+        if from_commit and to_commit and from_commit == to_commit:  # Use 'single' param to avoid Warning
+            self.repo_miner = RepositoryMining(path_to_repo, single=from_commit)
 
-        if from_commit != to_commit:
+        else:
             self.repo_miner = RepositoryMining(path_to_repo=path_to_repo,
+                                               since=since,
+                                               to=to,
                                                from_commit=from_commit,
                                                to_commit=to_commit,
                                                order='reverse')

--- a/pydriller/metrics/process/process_metric.py
+++ b/pydriller/metrics/process/process_metric.py
@@ -2,6 +2,7 @@
 This module contains the abstract class to implement process metrics.
 """
 
+from datetime import datetime
 from pydriller import RepositoryMining
 
 class ProcessMetric:
@@ -10,17 +11,27 @@ class ProcessMetric:
     """
 
     def __init__(self, path_to_repo: str,
-                 from_commit: str,
-                 to_commit: str):
+                 since: datetime = None,
+                 to: datetime = None,
+                 from_commit: str = None,
+                 to_commit: str = None):
         """
         :path_to_repo: path to a single repo
-        :to_commit: the SHA of the commit to stop counting. If None, the
-            analysis starts from the latest commit
-        :from_commit: the SHA of the commit to start counting. If None, the
-            analysis ends to the first commit
+
+        :param datetime since: starting date
+
+        :param datetime to: ending date
+
+        :param str from_commit: starting commit (only if `since` is None)
+
+        :param str to_commit: ending commit (only if `to` is None)
         """
-        if not from_commit or not to_commit:
-            raise TypeError
+
+        if not since and not from_commit:
+            raise TypeError('You must pass one between since and from_commit')
+
+        if not to and not to_commit:
+            raise TypeError('You must pass one between to and to_commit')
 
         self.repo_miner = RepositoryMining(path_to_repo, single=from_commit)
 

--- a/tests/metrics/process/test_change_set.py
+++ b/tests/metrics/process/test_change_set.py
@@ -1,4 +1,5 @@
 import pytest
+from datetime import datetime
 from pydriller.metrics.process.change_set import ChangeSet
 
 TEST_DATA = [
@@ -6,10 +7,27 @@ TEST_DATA = [
 ]
 
 @pytest.mark.parametrize('path_to_repo, from_commit, to_commit, expected_max, expected_avg', TEST_DATA)
-def test(path_to_repo, from_commit, to_commit, expected_max, expected_avg):
+def test_with_commits(path_to_repo, from_commit, to_commit, expected_max, expected_avg):
     metric = ChangeSet(path_to_repo=path_to_repo,
                        from_commit=from_commit,
                        to_commit=to_commit)
+
+    actual_max = metric.max()
+    actual_avg = metric.avg()
+
+    assert actual_max == expected_max
+    assert actual_avg == expected_avg
+
+
+TEST_DATA = [
+    ('test-repos/pydriller', datetime(2018, 3, 21), datetime(2018, 3, 27), 13, 8)
+]
+
+@pytest.mark.parametrize('path_to_repo, since, to, expected_max, expected_avg', TEST_DATA)
+def test_with_dates(path_to_repo, since, to, expected_max, expected_avg):
+    metric = ChangeSet(path_to_repo=path_to_repo,
+                       since=since,
+                       to=to)
 
     actual_max = metric.max()
     actual_avg = metric.avg()

--- a/tests/metrics/process/test_code_churn.py
+++ b/tests/metrics/process/test_code_churn.py
@@ -1,5 +1,8 @@
-import pytest
 from pathlib import Path
+from datetime import datetime
+
+import pytest
+
 from pydriller.metrics.process.code_churn import CodeChurn
 
 TEST_DATA = [
@@ -7,7 +10,7 @@ TEST_DATA = [
 ]
 
 @pytest.mark.parametrize('path_to_repo, filepath, from_commit, to_commit, expected_count, expected_max, expected_avg', TEST_DATA)
-def test(path_to_repo, filepath, from_commit, to_commit, expected_count, expected_max, expected_avg):
+def test_with_commits(path_to_repo, filepath, from_commit, to_commit, expected_count, expected_max, expected_avg):
     metric = CodeChurn(path_to_repo=path_to_repo,
                        from_commit=from_commit,
                        to_commit=to_commit)
@@ -21,3 +24,25 @@ def test(path_to_repo, filepath, from_commit, to_commit, expected_count, expecte
     assert actual_count[filepath] == expected_count
     assert actual_max[filepath] == expected_max
     assert actual_avg[filepath] == expected_avg
+
+
+TEST_DATA = [
+    ('test-repos/pydriller', 'domain/commit.py', datetime(2018, 3, 21), datetime(2018, 3, 27), 47, 34, 16)
+]
+
+@pytest.mark.parametrize('path_to_repo, filepath, since, to, expected_count, expected_max, expected_avg', TEST_DATA)
+def test_with_dates(path_to_repo, filepath, since, to, expected_count, expected_max, expected_avg):
+    metric = CodeChurn(path_to_repo=path_to_repo,
+                       since=since,
+                       to=to)
+
+    actual_count = metric.count()
+    actual_max = metric.max()
+    actual_avg = metric.avg()
+
+    filepath = str(Path(filepath))
+
+    assert actual_count[filepath] == expected_count
+    assert actual_max[filepath] == expected_max
+    assert actual_avg[filepath] == expected_avg
+

--- a/tests/metrics/process/test_commits_count.py
+++ b/tests/metrics/process/test_commits_count.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from datetime import datetime
 
 import pytest
 
@@ -9,13 +10,26 @@ TEST_DATA = [
     ('test-repos/pydriller', 'domain/developer.py', 'ab36bf45859a210b0eae14e17683f31d19eea041', 'fdf671856b260aca058e6595a96a7a0fba05454b', 2)
 ]
 
-
 @pytest.mark.parametrize('path_to_repo, filepath, from_commit, '
                          'to_commit, expected', TEST_DATA)
-def test(path_to_repo, filepath, from_commit, to_commit, expected):
+def test_with_commits(path_to_repo, filepath, from_commit, to_commit, expected):
     metric = CommitsCount(path_to_repo=path_to_repo,
                           from_commit=from_commit,
                           to_commit=to_commit)
+    count = metric.count()
+    filepath = str(Path(filepath))
+    assert count[filepath] == expected
+
+
+TEST_DATA = [
+    ('test-repos/pydriller', 'domain/developer.py', datetime(2018, 3, 21), datetime(2018, 3, 23), 2)
+]
+@pytest.mark.parametrize('path_to_repo, filepath, since, '
+                         'to, expected', TEST_DATA)
+def test_with_dates(path_to_repo, filepath, since, to, expected):
+    metric = CommitsCount(path_to_repo=path_to_repo,
+                          since=since,
+                          to=to)
     count = metric.count()
     filepath = str(Path(filepath))
     assert count[filepath] == expected

--- a/tests/metrics/process/test_contributors_count.py
+++ b/tests/metrics/process/test_contributors_count.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from datetime import datetime
 
 import pytest
 
@@ -10,10 +11,25 @@ TEST_DATA = [
 ]
 
 @pytest.mark.parametrize('path_to_repo, filepath, from_commit, to_commit, expected', TEST_DATA)
-def test(path_to_repo, filepath, from_commit, to_commit, expected):
+def test_with_commits(path_to_repo, filepath, from_commit, to_commit, expected):
     metric = ContributorsCount(path_to_repo=path_to_repo,
                                from_commit=from_commit,
                                to_commit=to_commit)
+
+    count = metric.count()
+    filepath = str(Path(filepath))
+    assert count[filepath] == expected
+
+TEST_DATA = [
+   ('test-repos/pydriller', 'pydriller/git_repository.py', datetime(2019, 12, 17), datetime(2019, 12, 24), 2),
+   ('test-repos/pydriller', 'domain/modification.py', datetime(2018, 3, 21), datetime(2018, 3, 27), 1)
+]
+
+@pytest.mark.parametrize('path_to_repo, filepath, since, to, expected', TEST_DATA)
+def test_with_dates(path_to_repo, filepath, since, to, expected):
+    metric = ContributorsCount(path_to_repo=path_to_repo,
+                               since=since,
+                               to=to)
 
     count = metric.count()
     filepath = str(Path(filepath))

--- a/tests/metrics/process/test_contributors_experience_count.py
+++ b/tests/metrics/process/test_contributors_experience_count.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from datetime import datetime
 
 import pytest
 
@@ -12,10 +13,26 @@ TEST_DATA = [
 ]
 
 @pytest.mark.parametrize('path_to_repo, filepath, from_commit, to_commit, expected', TEST_DATA)
-def test(path_to_repo, filepath, from_commit, to_commit, expected):
+def test_with_commits(path_to_repo, filepath, from_commit, to_commit, expected):
     metric = ContributorsExperience(path_to_repo=path_to_repo,
                                     from_commit=from_commit,
                                     to_commit=to_commit)
+    count = metric.count()
+    filepath = str(Path(filepath))
+    assert count[filepath] == expected
+
+
+TEST_DATA = [
+   ('test-repos/pydriller', 'domain/modification.py', datetime(2018, 3, 21), datetime(2018, 3, 23), 100.0),
+   ('test-repos/pydriller', 'pydriller/git_repository.py', datetime(2018, 8, 1), datetime(2018, 8, 2), 100.0),
+   ('test-repos/pydriller', 'pydriller/git_repository.py',  datetime(2018, 7, 23), datetime(2018, 8, 2), round(100*28/30, 2))
+]
+
+@pytest.mark.parametrize('path_to_repo, filepath, since, to, expected', TEST_DATA)
+def test_with_dates(path_to_repo, filepath, since, to, expected):
+    metric = ContributorsExperience(path_to_repo=path_to_repo,
+                                    since=since,
+                                    to=to)
     count = metric.count()
     filepath = str(Path(filepath))
     assert count[filepath] == expected

--- a/tests/metrics/process/test_history_complexity_count.py
+++ b/tests/metrics/process/test_history_complexity_count.py
@@ -1,7 +1,7 @@
 from pathlib import Path
+from datetime import datetime
 
 import pytest
-
 from pydriller.metrics.process.history_complexity import HistoryComplexity
 
 TEST_DATA = [
@@ -11,10 +11,26 @@ TEST_DATA = [
 ]
 
 @pytest.mark.parametrize('path_to_repo, filepath, from_commit, to_commit, expected', TEST_DATA)
-def test(path_to_repo, filepath, from_commit, to_commit, expected):
+def test_with_commits(path_to_repo, filepath, from_commit, to_commit, expected):
     metric = HistoryComplexity(path_to_repo=path_to_repo,
                                from_commit=from_commit,
                                to_commit=to_commit)
+    
+    count = metric.count()
+    filepath = str(Path(filepath))
+    assert count[filepath] == expected
+
+
+TEST_DATA = [
+    ('test-repos/pydriller', 'scm/git_repository.py', datetime(2018, 3, 22, 11, 30), datetime(2018, 3, 23), 40.49),
+    ('test-repos/pydriller', 'scm/git_repository.py', datetime(2018, 3, 22, 11, 30), datetime(2018, 3, 27), 47.05),
+]
+
+@pytest.mark.parametrize('path_to_repo, filepath, since, to, expected', TEST_DATA)
+def test_with_dates(path_to_repo, filepath, since, to, expected):
+    metric = HistoryComplexity(path_to_repo=path_to_repo,
+                               since=since,
+                               to=to)
     
     count = metric.count()
     filepath = str(Path(filepath))

--- a/tests/metrics/process/test_hunks_count.py
+++ b/tests/metrics/process/test_hunks_count.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from datetime import datetime
 
 import pytest
 
@@ -11,11 +12,27 @@ TEST_DATA = [
 ]
 
 @pytest.mark.parametrize('path_to_repo, filepath, from_commit, to_commit, expected', TEST_DATA)
-def test(path_to_repo, filepath, from_commit, to_commit, expected):
+def test_with_commits(path_to_repo, filepath, from_commit, to_commit, expected):
     metric = HunksCount(path_to_repo=path_to_repo,
                         from_commit=from_commit,
                         to_commit=to_commit)
-    
+
+    count = metric.count()
+    filepath = str(Path(filepath))
+    assert count[filepath] == expected
+
+TEST_DATA = [
+    ('test-repos/pydriller', 'scm/git_repository.py', datetime(2018, 3, 26), datetime(2018, 3, 27), 8),
+    ('test-repos/pydriller', 'scm/git_repository.py', datetime(2018, 3, 21), datetime(2018, 3, 27), 3),
+    ('test-repos/pydriller', 'domain/modification.py', datetime(2018, 3, 21), datetime(2018, 3, 22, 23), 1)
+]
+
+@pytest.mark.parametrize('path_to_repo, filepath, since, to, expected', TEST_DATA)
+def test_with_dates(path_to_repo, filepath, since, to, expected):
+    metric = HunksCount(path_to_repo=path_to_repo,
+                        since=since,
+                        to=to)
+
     count = metric.count()
     filepath = str(Path(filepath))
     assert count[filepath] == expected

--- a/tests/metrics/process/test_lines_added.py
+++ b/tests/metrics/process/test_lines_added.py
@@ -1,5 +1,8 @@
-import pytest
 from pathlib import Path
+from datetime import datetime
+
+import pytest
+
 from pydriller.metrics.process.lines_count import LinesCount
 
 TEST_DATA = [
@@ -8,10 +11,31 @@ TEST_DATA = [
 ]
 
 @pytest.mark.parametrize('path_to_repo, filepath, from_commit, to_commit, expected_count, expected_max, expected_avg', TEST_DATA)
-def test(path_to_repo, filepath, from_commit, to_commit, expected_count, expected_max, expected_avg):
+def test_with_commits(path_to_repo, filepath, from_commit, to_commit, expected_count, expected_max, expected_avg):
     metric = LinesCount(path_to_repo=path_to_repo,
                         from_commit=from_commit,
                         to_commit=to_commit)
+
+    actual_count = metric.count_added()
+    actual_max = metric.max_added()
+    actual_avg = metric.avg_added()
+
+    filepath = str(Path(filepath))
+
+    assert actual_count[filepath] == expected_count
+    assert actual_max[filepath] == expected_max
+    assert actual_avg[filepath] == expected_avg
+
+TEST_DATA = [
+   ('test-repos/pydriller', '.gitignore', datetime(2018, 3, 21), datetime(2018, 3, 22), 197, 197, 197),
+   ('test-repos/pydriller', 'domain/modification.py', datetime(2018, 3, 21), datetime(2018, 3, 27), 61, 48, 20)
+]
+
+@pytest.mark.parametrize('path_to_repo, filepath, since, to, expected_count, expected_max, expected_avg', TEST_DATA)
+def test_with_dates(path_to_repo, filepath, since, to, expected_count, expected_max, expected_avg):
+    metric = LinesCount(path_to_repo=path_to_repo,
+                        since=since,
+                        to=to)
 
     actual_count = metric.count_added()
     actual_max = metric.max_added()

--- a/tests/metrics/process/test_lines_count.py
+++ b/tests/metrics/process/test_lines_count.py
@@ -1,5 +1,8 @@
-import pytest
 from pathlib import Path
+from datetime import datetime
+
+import pytest
+
 from pydriller.metrics.process.lines_count import LinesCount
 
 TEST_DATA = [
@@ -8,10 +11,26 @@ TEST_DATA = [
 ]
 
 @pytest.mark.parametrize('path_to_repo, filepath, from_commit, to_commit, expected_count', TEST_DATA)
-def test(path_to_repo, filepath, from_commit, to_commit, expected_count):
+def test_with_commits(path_to_repo, filepath, from_commit, to_commit, expected_count):
     metric = LinesCount(path_to_repo=path_to_repo,
                         from_commit=from_commit,
                         to_commit=to_commit)
+
+    actual_count = metric.count()
+    filepath = str(Path(filepath))
+
+    assert actual_count[filepath] == expected_count
+
+TEST_DATA = [
+   ('test-repos/pydriller', '.gitignore', datetime(2018, 3, 21), datetime(2018, 3, 22), 197),
+   ('test-repos/pydriller', 'domain/modification.py', datetime(2018, 3, 21), datetime(2018, 3, 27), 65)
+]
+
+@pytest.mark.parametrize('path_to_repo, filepath, since, to, expected_count', TEST_DATA)
+def test_with_dates(path_to_repo, filepath, since, to, expected_count):
+    metric = LinesCount(path_to_repo=path_to_repo,
+                        since=since,
+                        to=to)
 
     actual_count = metric.count()
     filepath = str(Path(filepath))

--- a/tests/metrics/process/test_lines_removed.py
+++ b/tests/metrics/process/test_lines_removed.py
@@ -1,5 +1,8 @@
-import pytest
 from pathlib import Path
+from datetime import datetime
+
+import pytest
+
 from pydriller.metrics.process.lines_count import LinesCount
 
 TEST_DATA = [
@@ -8,10 +11,31 @@ TEST_DATA = [
 ]
 
 @pytest.mark.parametrize('path_to_repo, filepath, from_commit, to_commit, expected_count, expected_max, expected_avg', TEST_DATA)
-def test(path_to_repo, filepath, from_commit, to_commit, expected_count, expected_max, expected_avg):
+def test_with_commits(path_to_repo, filepath, from_commit, to_commit, expected_count, expected_max, expected_avg):
     metric = LinesCount(path_to_repo=path_to_repo,
                         from_commit=from_commit,
                         to_commit=to_commit)
+
+    actual_count = metric.count_removed()
+    actual_max = metric.max_removed()
+    actual_avg = metric.avg_removed()
+
+    filepath = str(Path(filepath))
+
+    assert actual_count[filepath] == expected_count
+    assert actual_max[filepath] == expected_max
+    assert actual_avg[filepath] == expected_avg
+
+TEST_DATA = [
+   ('test-repos/pydriller', '.gitignore', datetime(2018, 3, 21), datetime(2018, 3, 22), 0, 0, 0),
+   ('test-repos/pydriller', 'domain/modification.py', datetime(2018, 3, 21), datetime(2018, 3, 27), 4, 3, 1)
+]
+
+@pytest.mark.parametrize('path_to_repo, filepath, since, to, expected_count, expected_max, expected_avg', TEST_DATA)
+def test_with_dates(path_to_repo, filepath, since, to, expected_count, expected_max, expected_avg):
+    metric = LinesCount(path_to_repo=path_to_repo,
+                        since=since,
+                        to=to)
 
     actual_count = metric.count_removed()
     actual_max = metric.max_removed()

--- a/tests/metrics/process/test_minor_contributors_count.py
+++ b/tests/metrics/process/test_minor_contributors_count.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from datetime import datetime
 
 import pytest
 
@@ -11,10 +12,28 @@ TEST_DATA = [
 ]
 
 @pytest.mark.parametrize('path_to_repo, filepath, from_commit, to_commit, expected', TEST_DATA)
-def test(path_to_repo, filepath, from_commit, to_commit, expected):
+def test_with_commits(path_to_repo, filepath, from_commit, to_commit, expected):
     metric = ContributorsCount(path_to_repo=path_to_repo,
                                from_commit=from_commit,
                                to_commit=to_commit)
+
+    count = metric.count_minor()
+    filepath = str(Path(filepath))
+    assert count[filepath] == expected
+
+
+TEST_DATA = [
+   ('test-repos/pydriller', 'pydriller/git_repository.py', datetime(2018, 8, 1), datetime(2018, 8, 2), 0),
+   ('test-repos/pydriller', 'pydriller/git_repository.py', datetime(2018, 3, 21), datetime(2018, 8, 2), 1),
+   ('test-repos/pydriller', 'pydriller/git_repository.py', datetime(2018, 3, 21), datetime(2019, 1, 14, 10), 2)
+]
+
+@pytest.mark.parametrize('path_to_repo, filepath, since, to, expected', TEST_DATA)
+def test_with_dates(path_to_repo, filepath, since, to, expected):
+    metric = ContributorsCount(path_to_repo=path_to_repo,
+                               since=since,
+                               to=to)
+
     count = metric.count_minor()
     filepath = str(Path(filepath))
     assert count[filepath] == expected

--- a/tests/metrics/process/test_process_metric.py
+++ b/tests/metrics/process/test_process_metric.py
@@ -1,0 +1,22 @@
+import pytest
+
+from datetime import datetime
+from pydriller.metrics.process.process_metric import ProcessMetric
+
+dt1 = datetime(2016, 10, 8, 17, 0, 0)
+dt2 = datetime(2016, 10, 8, 17, 59, 0)
+
+TEST_DATA = [
+    ('test-repos/pydriller', None, dt2, None, '81ddf7e78d92f3aaa212d5924d1ae0ed1fd980e6'), # Test (if not since and not from_commit) 
+    ('test-repos/pydriller', dt1, None, 'ab36bf45859a210b0eae14e17683f31d19eea041', None)  # Test (if not to and not to_commit) 
+]
+
+@pytest.mark.parametrize('path_to_repo, since, to, from_commit, to_commit', TEST_DATA)
+def test_type_error(path_to_repo, since, to, from_commit, to_commit):
+
+    with pytest.raises(TypeError):
+        ProcessMetric(path_to_repo=path_to_repo,
+                      since=since,
+                      to=to,
+                      from_commit=from_commit,
+                      to_commit=to_commit)


### PR DESCRIPTION
Before this enhancement, the user could run process metrics solely between two commits. 
Now it is possible to specify two dates.

I am sorry for the large number of modified files in the PR, but they are mostly test data/cases added using the same template.


