### PR TITLE
Arguments that enable '--all' and '--remotes' for git rev-list

### DIFF
--- a/pydriller/repository_mining.py
+++ b/pydriller/repository_mining.py
@@ -43,6 +43,8 @@ class RepositoryMining:
                  since: datetime = None, to: datetime = None,
                  from_commit: str = None, to_commit: str = None,
                  from_tag: str = None, to_tag: str = None,
+                 include_refs: bool = False,
+                 include_remotes: bool = False,
                  reversed_order: bool = False,
                  only_in_branch: str = None,
                  only_modifications_with_file_types: List[str] = None,
@@ -77,6 +79,8 @@ class RepositoryMining:
             if `since` and `from_commit` are None)
         :param str to_tag: ending the analysis from specified tag (only if
             `to` and `to_commit` are None)
+        :param bool include_refs: whether to include refs and HEAD in commit analysis
+        :param bool include_remotes: whether to include remote commits in analysis
         :param bool reversed_order: whether the commits should be analyzed
             in reversed order (**DEPRECATED**)
         :param str only_in_branch: only commits in this branch will be analyzed
@@ -96,7 +100,7 @@ class RepositoryMining:
         if only_commits is not None:
             only_commits = set(only_commits)
         if reversed_order:
-            logger.info("'reversed_oder' is deprecated and will be removed in the next release. "
+            logger.info("'reversed_order' is deprecated and will be removed in the next release. "
                         "Use 'order=reverse' instead. ")
             order = 'reverse'
 
@@ -110,6 +114,8 @@ class RepositoryMining:
             "since": since,
             "to": to,
             "single": single,
+            "include_refs": include_refs,
+            "include_remotes": include_remotes,
             "only_in_branch": only_in_branch,
             "only_modifications_with_file_types": only_modifications_with_file_types,
             "only_no_merge": only_no_merge,

--- a/pydriller/utils/conf.py
+++ b/pydriller/utils/conf.py
@@ -195,6 +195,8 @@ class Conf:
         until = self.get('to')
         from_commit = self.get('from_commit')
         to_commit = self.get('to_commit')
+        include_refs = self.get('include_refs')
+        remotes = self.get('include_remotes')
         branch = self.get('only_in_branch')
         authors = self.get('only_authors')
         order = self.get('order')
@@ -230,6 +232,12 @@ class Conf:
             kwargs['author-date-order'] = True
         elif order == 'topo-order':
             kwargs['topo-order'] = True
+
+        if include_refs is not None:
+            kwargs['all'] = include_refs
+
+        if remotes is not None:
+            kwargs['remotes'] = remotes
 
         if authors is not None:
             kwargs['author'] = authors


### PR DESCRIPTION
These changes allow a user of pydriller to pass the 'include_refs' and 'include_remotes' arguments to RepositoryMiner that enable '--all' and '--remotes' in rev-list, respectively.

I found that these tweaks helped me to be more flexible and performant while using this package and I wanted to contribute to help out.

Keep up the good work!