### PR TITLE
Open Source Delta Maintainability Model Support

### DIFF
--- a/docs/deltamaintainability.rst
+++ b/docs/deltamaintainability.rst
@@ -1,4 +1,4 @@
-.. _deltamaintainability_:
+.. _deltamaintainability:
 
 =====================
 Delta Maintainability
@@ -30,6 +30,7 @@ The delta risk profile can then be used to determine good and bad change:
 
 The dmm value is then computed as: *good change / (good change + bad change)*.
 
+.. _Properties:
 
 Properties
 ==========

--- a/docs/deltamaintainability.rst
+++ b/docs/deltamaintainability.rst
@@ -1,0 +1,97 @@
+.. _deltamaintainability_:
+
+=====================
+Delta Maintainability
+=====================
+
+Background
+==========
+
+To assess the maintainability implications of commits, PyDriller offers an implementation of the *Open Source Delta Maintainability Model* (OS-DMM). The underlying Delta Maintainability Model was originally described in a paper that appeared at TechDebt 2019 [DiBiase2019]_.
+A commercially available implementation supporting over 100 different languages with fine-grained analysis is offered by the `Software Improvement Group <https://www.softwareimprovementgroup.com/>`_ (SIG).
+
+The Open Source implementation included in PyDriller offers a partial implementation suitable for research experiments and measurements for systems written in common programming languages already supported by PyDriller. While the git-functionality of PyDriller is language agnostic, the *metrics* (such as method size and cyclomatic complexity) it supports require language-specific implementations -- for  which PyDriller relies on `Lizard <https://github.com/terryyin/lizard>`_.
+
+The OS-DMM implementation extends the PyDriller metrics with three commit-level metrics related to risk in size, complexity, and interfacing.
+
+Definition
+==========
+
+In one sentence, the delta-maintainability metric is the proportion of *low-risk change* in a commit. The resulting value ranges from 0.0 (all changes are risky) to 1.0 (all changes are low risk). It rewards making methods better, and penalizes making things worse.
+
+The starting point for the DMM is a *risk profile* [Heitlager2007]_. Traditionally, risk profiles categorize methods (or, more generally, also referred to as *units*) into four bins: low, medium, high, and very high risk methods. The risk profile of a class then is a 4-tuple (*l, m, h, v*) representing the amount (lines) of code in each of the four  categories.
+
+For simplicity, in the context of the DMM, only two bins are used: low risk, and non-low (medium, high, or very high) risk. To transfer risk profiles from file (or system) level to commit level, we consider *delta risk profiles*. These are pairs (*dl, dh*), with *dl* being the increase (or decrease) of low risk code, and *dl* the increase (or decrease) in high risk code.
+
+The delta risk profile can then be used to determine good and bad change:
+
+- Increases in low risk code are good, but increases in high risk code are bad.
+- Decreases in high risk code are good, and decreases in low risk code are good only if no high risk code is added instead, and bad otherwise.
+
+The dmm value is then computed as: *good change / (good change + bad change)*.
+
+
+Properties
+==========
+
+The DMM can be used on arbitrary properties that can be determined at method (unit) level. The PyDriller OS-DMM implementation supports three properties:
+
+- Unit **size**: Method length in lines of code; low risk threshold 15 lines.
+- Unit **complexity**: Method cyclomatic complexity; low risk threshold 5.
+- Unit **interfacing**: Method number of parameters: low risk threshold 2.
+
+The original DMM paper also used coupling and cloned code as properties, but these are not easily computed per commit with the Lizard infrastructure. The thresholds have been determined empirically following the procedure described in [Alves2010]_.
+
+Example usage
+=============
+
+Collecting DMM values from a git repository is  straightforward::
+
+	from pydriller import RepositoryMining
+
+	rm = RepositoryMining("https://github.com/avandeursen/dmm-test-repo")
+	for commit in rm.traverse_commits():
+		print("| {} | {} | {} | {} |".format(
+			commit.msg,
+			commit.dmm_unit_size,
+			commit.dmm_unit_complexity,
+			commit.dmm_unit_interfacing
+			))
+
+
+Under the hood
+==============
+
+The main public API consists of the three ``dmm_unit_size``, ``dmm_unit_complexity``, and ``dmm_unit_interfacing`` properties on the ``Commit`` class, as illustrated above.
+
+Under the hood, the DMM implementation can be easily configured or accessed:
+
+- The thresholds are set as separate constants in the ``Commit`` class;
+- The main methods implementing the DMM  are parameterized with a predicate characterizing low risk methods: This makes it easy to  expand the implementation with other properties;
+- There  are separate (protected) methods to compute risk profiles and delta-risk profiles and ``Commit`` and ``Modification`` level, which can be used to conduct root cause analysis for lowly rated commits.
+
+
+Relation to SIG DMM
+===================
+
+PyDriller's OS-DMM and SIG's DMM differ in the following ways:
+
+- OS-DMM offers only support for the approximately 15 languages supported by `Lizard <https://github.com/terryyin/lizard>`_.
+- OS-DMM relies on Lizard for the identification of *methods* (units) in source files. While for simple cases SIG and Lizard tooling will agree, this may not be the case for more intricate cases involving e.g., lambdas, inner classes, nested functions, etc.
+- OS-DMM relies on Lizard for simple line counting, which also counts white space. SIG's DMM on the other hand ignores blank lines.
+- OS-DMM uses the thresholds as empirically determined by SIG, based on SIG's measurement methodology [Alves2010]_. OS-DMM's Lizard-based metric values may be different, and hence may classify methods in different risk bins for methods close to the thresholds.
+
+Consequently, individual DMM values are likely to differ a few percentages between the SIG DMM and OS-DMM implementations. However, in terms of trends and statistical analysis, the outcomes will likely be very similar.
+Therefore:
+
+- For research purposes, we recommend the fully open PyDriller implementation ensuring reproducible results.
+- For commercial purposes including day to day monitoring of maintainability at commit, code, file, component, project, and portfolio level, we recommend the more robust SIG implementation.
+
+References
+==========
+
+.. [DiBiase2019] Marco di Biase, Ayushi Rastogi, Magiel Bruntink, and Arie van Deursen. **The Delta Maintainability Model: measuring maintainability of fine-grained code changes**. IEEE/ACM International Conference on Technical Debt (TechDebt) at ICSE 2019, pp 113-122 (`preprint <https://pure.tudelft.nl/portal/en/publications/the-delta-maintainability-model-measuring-maintainability-of-finegrained-code-changes(6ff67dee-2781-47d7-916f-bd36c5b61beb).html>`_, `doi <https://doi.org/10.1109/TechDebt.2019.00030>`_)
+
+.. [Heitlager2007] Ilja Heitlager, Tobias Kuipers, Joost Visser. **A Practical Model for Measuring Maintainability**. 6th International Conference on the Quality of Information and Communications Technology, QUATIC 2007, IEEE, pp 30-39 (`preprint <http://wiki.di.uminho.pt/twiki/pub/Personal/Joost/PublicationList/HeitlagerKuipersVisser-Quatic2007.pdf>`_, `doi <https://doi.org/10.1109/QUATIC.2007.8>`_)
+
+.. [Alves2010]  Tiaga Alves, Christiaan Ypma, and Joost Visser. **Deriving metric thresholds from benchmark data**. IEEE International Conference on Software Maintenance (ICSM), pages 1–10. IEEE, 2010. (`preprint <http://wiki.di.uminho.pt/twiki/pub/Personal/Tiago/Publications/icsm10rt-alves.pdf>`_, `doi <https://doi.org/10.1109/ICSM.2010.5609747>`_)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,6 +15,7 @@ PyDriller documentation!
    commit
    modifications
    gitrepository
+   deltamaintainability
    processmetrics
    reference
 

--- a/tests/test_dmm.py
+++ b/tests/test_dmm.py
@@ -16,7 +16,7 @@ import logging
 import pytest
 
 from pydriller.git_repository import GitRepository
-from pydriller.domain.commit import Commit
+from pydriller.domain.commit import Commit, DMMProperty
 
 
 logging.basicConfig(
@@ -120,17 +120,17 @@ def test_dmm_unit_interfacing(repo: GitRepository, msg: str, dmm: float):
 def test_delta_profile_modification(repo: GitRepository):
     commit = commit_by_msg(repo, 'Increase unit size to risky')
     mod = commit.modifications[0]
-    assert mod._delta_risk_profile(commit._low_risk_unit_size) == (-15, 16)
+    assert mod._delta_risk_profile(DMMProperty.UNIT_SIZE) == (-15, 16)
 
 def test_delta_profile_commit(repo: GitRepository):
     commit = commit_by_msg(repo, 'Increase in one, decrease in other file')
 
     m0 = commit.modifications[0]
-    assert m0._delta_risk_profile(commit._low_risk_unit_size) == (0, 1)
+    assert m0._delta_risk_profile(DMMProperty.UNIT_SIZE) == (0, 1)
     m1 = commit.modifications[1]
-    assert m1._delta_risk_profile(commit._low_risk_unit_size) == (3, 0)
+    assert m1._delta_risk_profile(DMMProperty.UNIT_SIZE) == (3, 0)
 
-    assert commit._delta_risk_profile(Commit._low_risk_unit_size) == (3, 1)
+    assert commit._delta_risk_profile(DMMProperty.UNIT_SIZE) == (3, 1)
 
 @pytest.mark.parametrize(
     'dlo,dhi,prop', [

--- a/tests/test_dmm.py
+++ b/tests/test_dmm.py
@@ -1,0 +1,148 @@
+# Copyright 2018 Davide Spadini and Arie van Deursen
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import pytest
+
+from pydriller.git_repository import GitRepository
+from pydriller.domain.commit import Commit
+
+
+logging.basicConfig(
+    format='%(asctime)s - %(levelname)s - %(message)s', level=logging.INFO)
+
+
+@pytest.fixture()
+def repo():
+    path = "test-repos/dmm-test-repo"
+    gr = GitRepository(path)
+    yield gr
+    gr.clear()
+
+
+# List of (commit_message, dmm_value) pairs
+#
+# We use unit size to exercise all the various DMM cases
+UNIT_SIZE_TEST_DATA = [
+    # delta high > 0, delta low = 0 -- always DMM 0.0
+    ('Commit with one large method', 0.0),
+
+    # delta high > 0, delta low > 0 -- DMM = ratio
+    ('Make large larger, add small method', 0.8),
+
+    # delta high > 0, delta low < 0 --- always DMM 0.0
+    ('Make large larger, make small smaller', 0.0),
+
+    # delta high = 0, delta low = 0 --- always DMM 1.0
+    ('Modify every line in large method', 1.0),
+
+    # delta high = 0, delta low > 0 --- always DMM 1.0
+    ('Make small method a bit larger', 1.0),
+
+    # delta high = 0, delta low < 0 --- alwyas DMM 1.0 (corner case)
+    ('Make small smaller', 1.0),
+
+    # delta high < 0, delta low < 0 --- DMM = ratio
+    ('Make large smaller, make small smaller', 2/3),
+
+    # delta  high < 0, delta low = 0 -- always 1.0
+    ('Make large smaller', 1.0),
+
+    # delta high < 0, delta low > 0 -- always DMM 1.0
+    ('Make large smaller, make small larger', 1.0),
+
+    # File 1: large larger; File 2: small larger -- dmm fraction
+    ('Increase in one, decrease in other file', 3/4),
+
+    # Method with unit size exactly on the border
+    ('Add method with unit size on-point', 1.0),
+
+    # Method with unit size at off point
+    ('Increase unit size to risky', 0.0)
+]
+
+UNIT_COMPLEXITY_TEST_DATA = [
+    # Large method, but no conditional logic
+    ('Commit with one large method', 1.0),
+
+    # Method with cyclomatic complexity exactly on the border
+    ('Add method with complexity on-point', 1.0),
+
+    # Method with cyclomatic complexity at off point
+    ('Increase complexity to risky', 0.0)
+]
+
+UNIT_INTERFACING_TEST_DATA = [
+    # Large method, but no parameters
+    ('Commit with one large method', 1.0),
+
+    # Method with nr of paramters exactly on the border
+    ('Add method with interfacing on-point', 1.0),
+
+    # Method with nr of parameters at off point
+    ('Increase interfacing to risky', 0.0)
+]
+
+
+def commit_by_msg(repo: GitRepository, msg: str) -> Commit:
+    for commit in repo.get_list_commits():
+        if commit.msg == msg:
+            return commit
+    logging.warning('cannot find commit with msg "%s"', msg)
+    return None
+
+@pytest.mark.parametrize('msg,dmm', UNIT_SIZE_TEST_DATA)
+def test_dmm_unit_size(repo: GitRepository, msg: str, dmm: float):
+    commit = commit_by_msg(repo, msg)
+    assert commit.dmm_unit_size == dmm
+
+@pytest.mark.parametrize('msg,dmm', UNIT_COMPLEXITY_TEST_DATA)
+def test_dmm_unit_complexity(repo: GitRepository, msg: str, dmm: float):
+    commit = commit_by_msg(repo, msg)
+    assert commit.dmm_unit_complexity == dmm
+
+@pytest.mark.parametrize('msg,dmm', UNIT_INTERFACING_TEST_DATA)
+def test_dmm_unit_interfacing(repo: GitRepository, msg: str, dmm: float):
+    commit = commit_by_msg(repo, msg)
+    assert commit.dmm_unit_interfacing == dmm
+
+def test_delta_profile_modification(repo: GitRepository):
+    commit = commit_by_msg(repo, 'Increase unit size to risky')
+    mod = commit.modifications[0]
+    assert mod._delta_risk_profile(commit._low_risk_unit_size) == (-15, 16)
+
+def test_delta_profile_commit(repo: GitRepository):
+    commit = commit_by_msg(repo, 'Increase in one, decrease in other file')
+
+    m0 = commit.modifications[0]
+    assert m0._delta_risk_profile(commit._low_risk_unit_size) == (0, 1)
+    m1 = commit.modifications[1]
+    assert m1._delta_risk_profile(commit._low_risk_unit_size) == (3, 0)
+
+    assert commit._delta_risk_profile(Commit._low_risk_unit_size) == (3, 1)
+
+@pytest.mark.parametrize(
+    'dlo,dhi,prop', [
+    ( 0,  0, 1.0),
+    ( 1,  0, 1.0),
+    (-1,  0, 0.0),
+    ( 0,  1, 0.0),
+    ( 0, -1, 1.0),
+    ( 1,  1, 0.5),
+    (-1, -1, 0.5),
+    ( 1, -1, 1.0),
+    (-1,  1, 0.0)
+    ])
+def test_good_proportion(dlo: int, dhi: int, prop: float):
+    assert Commit._good_change_proportion(dlo, dhi) == prop


### PR DESCRIPTION
This pull request extends PyDriller with support for the Delta Maintainability Model. It offers metrics to characterize the change in maintainability caused by commit, focusing on the proportion of *low-risk change* in a commit. 

The pull request offers:

- `docs/deltamaintainability.rst`: Documentation of the origins of the model, its usage in PyDriller, and the `Commit` API extensions with `dmm_unit_size`, `dmm_unit_complexity`, and `dmm_unit_interfacing`.
- `pydriller/domain/commit.py`: Implementation of the model in the `Commit` and `Modification` classes
- `tests/test_dmm.py`: Series of test cases covering all corner cases and all branches
- `test-repos.zip`: Extended with test repo  available at https://github.com/avandeursen/dmm-test-repo

See also Marco di Biase, Ayushi Rastogi, Magiel Bruntink, and Arie van Deursen. The Delta Maintainability Model: measuring maintainability of fine-grained code changes. IEEE/ACM International Conference on Technical Debt (TechDebt) at ICSE 2019, pp 113-122 ([preprint and doi](https://pure.tudelft.nl/portal/en/publications/the-delta-maintainability-model-measuring-maintainability-of-finegrained-code-changes(6ff67dee-2781-47d7-916f-bd36c5b61beb).html)).


