### PR TITLE
Resolution of open MyPy Issues

### DIFF
--- a/pydriller/domain/commit.py
+++ b/pydriller/domain/commit.py
@@ -152,11 +152,11 @@ class Modification:  # pylint: disable=R0902
         self.source_code = diff_and_sc['source_code']
         self.source_code_before = diff_and_sc['source_code_before']
 
-        self._nloc: Optional[int] = None
-        self._complexity: Optional[int] = None
-        self._token_count: Optional[int] = None
-        self._function_list: List[Method] = []
-        self._function_list_before: List[Method] = []
+        self._nloc = None
+        self._complexity = None
+        self._token_count = None
+        self._function_list = [] # type: List[Method]
+        self._function_list_before = []  # type: List[Method]
 
     @property
     def added(self) -> int:
@@ -267,7 +267,7 @@ class Modification:  # pylint: disable=R0902
         :return: Dictionary
         """
         lines = self.diff.split('\n')
-        modified_lines: Dict[str, List[Tuple[int, str]]] = {'added': [], 'deleted': []}
+        modified_lines = {'added': [], 'deleted': []} # type: Dict[str, List[Tuple[int, str]]] 
 
         count_deletions = 0
         count_additions = 0

--- a/pydriller/domain/commit.py
+++ b/pydriller/domain/commit.py
@@ -21,7 +21,7 @@ import logging
 from _datetime import datetime
 from enum import Enum
 from pathlib import Path
-from typing import List, Set, Dict, Tuple
+from typing import List, Set, Dict, Tuple, Optional
 
 import lizard
 from git import Diff, Git, Commit as GitCommit, NULL_TREE
@@ -152,11 +152,11 @@ class Modification:  # pylint: disable=R0902
         self.source_code = diff_and_sc['source_code']
         self.source_code_before = diff_and_sc['source_code_before']
 
-        self._nloc = None
-        self._complexity = None
-        self._token_count = None
-        self._function_list = []
-        self._function_list_before = []
+        self._nloc: Optional[int] = None
+        self._complexity: Optional[int] = None
+        self._token_count: Optional[int] = None
+        self._function_list: List[Method] = []
+        self._function_list_before: List[Method] = []
 
     @property
     def added(self) -> int:
@@ -230,6 +230,7 @@ class Modification:  # pylint: disable=R0902
         :return: LOC of the file
         """
         self._calculate_metrics()
+        assert self._nloc is not None
         return self._nloc
 
     @property
@@ -240,6 +241,7 @@ class Modification:  # pylint: disable=R0902
         :return: Cyclomatic Complexity of the file
         """
         self._calculate_metrics()
+        assert self._complexity is not None
         return self._complexity
 
     @property
@@ -250,6 +252,7 @@ class Modification:  # pylint: disable=R0902
         :return: token count
         """
         self._calculate_metrics()
+        assert self._token_count is not None
         return self._token_count
 
     @property
@@ -264,7 +267,7 @@ class Modification:  # pylint: disable=R0902
         :return: Dictionary
         """
         lines = self.diff.split('\n')
-        modified_lines = {'added': [], 'deleted': []}
+        modified_lines: Dict[str, List[Tuple[int, str]]] = {'added': [], 'deleted': []}
 
         count_deletions = 0
         count_additions = 0
@@ -539,6 +542,7 @@ class Commit:
         if self._modifications is None:
             self._modifications = self._get_modifications()
 
+        assert self._modifications is not None
         return self._modifications
 
     def _get_modifications(self):
@@ -630,6 +634,7 @@ class Commit:
         if self._branches is None:
             self._branches = self._get_branches()
 
+        assert self._branches is not None
         return self._branches
 
     def _get_branches(self):

--- a/pydriller/git_repository.py
+++ b/pydriller/git_repository.py
@@ -275,7 +275,7 @@ class GitRepository:
                                 hashes_to_ignore_path: str = None) \
             -> Dict[str, Set[str]]:
 
-        commits = {}
+        commits: Dict[str, Set[str]] = {}
 
         for mod in modifications:
             path = mod.new_path

--- a/pydriller/git_repository.py
+++ b/pydriller/git_repository.py
@@ -304,7 +304,7 @@ class GitRepository:
 
         return commits
 
-    def _get_blame(self, commit_hash: str, path: str, hashes_to_ignore_path: List[str] = None):
+    def _get_blame(self, commit_hash: str, path: str, hashes_to_ignore_path: str = None):
         args = ['-w', commit_hash + '^']
         if hashes_to_ignore_path is not None:
             if self.git.version_info >= (2, 23):

--- a/pydriller/git_repository.py
+++ b/pydriller/git_repository.py
@@ -275,7 +275,7 @@ class GitRepository:
                                 hashes_to_ignore_path: str = None) \
             -> Dict[str, Set[str]]:
 
-        commits: Dict[str, Set[str]] = {}
+        commits = {} # type: Dict[str, Set[str]]
 
         for mod in modifications:
             path = mod.new_path

--- a/pydriller/repository_mining.py
+++ b/pydriller/repository_mining.py
@@ -95,10 +95,14 @@ class RepositoryMining:
         :param str order: order of commits. It can be one of: 'date-order',
             'author-date-order', 'topo-order', or 'reverse'. Default is reverse.
         """
-        if only_modifications_with_file_types is not None:
-            only_modifications_with_file_types = set(only_modifications_with_file_types)
-        if only_commits is not None:
-            only_commits = set(only_commits)
+        file_modification_set = (
+            None if only_modifications_with_file_types is None 
+            else set(only_modifications_with_file_types)
+            )
+        commit_set = (
+            None if only_commits is None
+            else set(only_commits)
+            )
         if reversed_order:
             logger.info("'reversed_order' is deprecated and will be removed in the next release. "
                         "Use 'order=reverse' instead. ")
@@ -117,10 +121,10 @@ class RepositoryMining:
             "include_refs": include_refs,
             "include_remotes": include_remotes,
             "only_in_branch": only_in_branch,
-            "only_modifications_with_file_types": only_modifications_with_file_types,
+            "only_modifications_with_file_types": file_modification_set,
             "only_no_merge": only_no_merge,
             "only_authors": only_authors,
-            "only_commits": only_commits,
+            "only_commits": commit_set,
             "only_releases": only_releases,
             "skip_whitespaces": skip_whitespaces,
             "filepath": filepath,

--- a/tests/metrics/process/test_change_set.py
+++ b/tests/metrics/process/test_change_set.py
@@ -2,11 +2,11 @@ import pytest
 from datetime import datetime
 from pydriller.metrics.process.change_set import ChangeSet
 
-TEST_DATA = [
+TEST_COMMIT_DATA = [
     ('test-repos/pydriller', 'ab36bf45859a210b0eae14e17683f31d19eea041', '71e053f61fc5d31b3e31eccd9c79df27c31279bf', 13, 8)
 ]
 
-@pytest.mark.parametrize('path_to_repo, from_commit, to_commit, expected_max, expected_avg', TEST_DATA)
+@pytest.mark.parametrize('path_to_repo, from_commit, to_commit, expected_max, expected_avg', TEST_COMMIT_DATA)
 def test_with_commits(path_to_repo, from_commit, to_commit, expected_max, expected_avg):
     metric = ChangeSet(path_to_repo=path_to_repo,
                        from_commit=from_commit,
@@ -19,12 +19,12 @@ def test_with_commits(path_to_repo, from_commit, to_commit, expected_max, expect
     assert actual_avg == expected_avg
 
 
-TEST_DATA = [
+TEST_DATE_DATA = [
     ('test-repos/pydriller', datetime(2018, 3, 21), datetime(2018, 3, 27), 13, 8),
     ('test-repos/pydriller', datetime(2018, 3, 23), datetime(2018, 3, 23), 0, 0)
 ]
 
-@pytest.mark.parametrize('path_to_repo, since, to, expected_max, expected_avg', TEST_DATA)
+@pytest.mark.parametrize('path_to_repo, since, to, expected_max, expected_avg', TEST_DATE_DATA)
 def test_with_dates(path_to_repo, since, to, expected_max, expected_avg):
     metric = ChangeSet(path_to_repo=path_to_repo,
                        since=since,

--- a/tests/metrics/process/test_code_churn.py
+++ b/tests/metrics/process/test_code_churn.py
@@ -5,11 +5,11 @@ import pytest
 
 from pydriller.metrics.process.code_churn import CodeChurn
 
-TEST_DATA = [
+TEST_COMMIT_DATA = [
     ('test-repos/pydriller', 'domain/commit.py', 'ab36bf45859a210b0eae14e17683f31d19eea041', '71e053f61fc5d31b3e31eccd9c79df27c31279bf', 47, 34, 16)
 ]
 
-@pytest.mark.parametrize('path_to_repo, filepath, from_commit, to_commit, expected_count, expected_max, expected_avg', TEST_DATA)
+@pytest.mark.parametrize('path_to_repo, filepath, from_commit, to_commit, expected_count, expected_max, expected_avg', TEST_COMMIT_DATA)
 def test_with_commits(path_to_repo, filepath, from_commit, to_commit, expected_count, expected_max, expected_avg):
     metric = CodeChurn(path_to_repo=path_to_repo,
                        from_commit=from_commit,
@@ -26,11 +26,11 @@ def test_with_commits(path_to_repo, filepath, from_commit, to_commit, expected_c
     assert actual_avg[filepath] == expected_avg
 
 
-TEST_DATA = [
+TEST_DATE_DATA = [
     ('test-repos/pydriller', 'domain/commit.py', datetime(2018, 3, 21), datetime(2018, 3, 27), 47, 34, 16)
 ]
 
-@pytest.mark.parametrize('path_to_repo, filepath, since, to, expected_count, expected_max, expected_avg', TEST_DATA)
+@pytest.mark.parametrize('path_to_repo, filepath, since, to, expected_count, expected_max, expected_avg', TEST_DATE_DATA)
 def test_with_dates(path_to_repo, filepath, since, to, expected_count, expected_max, expected_avg):
     metric = CodeChurn(path_to_repo=path_to_repo,
                        since=since,

--- a/tests/metrics/process/test_commits_count.py
+++ b/tests/metrics/process/test_commits_count.py
@@ -5,13 +5,13 @@ import pytest
 
 from pydriller.metrics.process.commits_count import CommitsCount
 
-TEST_DATA = [
+TEST_COMMIT_DATA = [
     ('test-repos/pydriller', 'domain/developer.py', 'fdf671856b260aca058e6595a96a7a0fba05454b', 'ab36bf45859a210b0eae14e17683f31d19eea041', 2),
     ('test-repos/pydriller', 'domain/developer.py', 'ab36bf45859a210b0eae14e17683f31d19eea041', 'fdf671856b260aca058e6595a96a7a0fba05454b', 2)
 ]
 
 @pytest.mark.parametrize('path_to_repo, filepath, from_commit, '
-                         'to_commit, expected', TEST_DATA)
+                         'to_commit, expected', TEST_COMMIT_DATA)
 def test_with_commits(path_to_repo, filepath, from_commit, to_commit, expected):
     metric = CommitsCount(path_to_repo=path_to_repo,
                           from_commit=from_commit,
@@ -21,11 +21,11 @@ def test_with_commits(path_to_repo, filepath, from_commit, to_commit, expected):
     assert count[filepath] == expected
 
 
-TEST_DATA = [
+TEST_DATE_DATA = [
     ('test-repos/pydriller', 'domain/developer.py', datetime(2018, 3, 21), datetime(2018, 3, 23), 2)
 ]
 @pytest.mark.parametrize('path_to_repo, filepath, since, '
-                         'to, expected', TEST_DATA)
+                         'to, expected', TEST_DATE_DATA)
 def test_with_dates(path_to_repo, filepath, since, to, expected):
     metric = CommitsCount(path_to_repo=path_to_repo,
                           since=since,

--- a/tests/metrics/process/test_contributors_count.py
+++ b/tests/metrics/process/test_contributors_count.py
@@ -5,12 +5,12 @@ import pytest
 
 from pydriller.metrics.process.contributors_count import ContributorsCount
 
-TEST_DATA = [
+TEST_COMMIT_DATA = [
    ('test-repos/pydriller', 'pydriller/git_repository.py', '8b69cae085581256adfdbd58c0e499395819b84d', '115953109b57d841ccd0952d70f8ed6703d175cd', 2),
    ('test-repos/pydriller', 'domain/modification.py', '71e053f61fc5d31b3e31eccd9c79df27c31279bf', 'ab36bf45859a210b0eae14e17683f31d19eea041', 1)
 ]
 
-@pytest.mark.parametrize('path_to_repo, filepath, from_commit, to_commit, expected', TEST_DATA)
+@pytest.mark.parametrize('path_to_repo, filepath, from_commit, to_commit, expected', TEST_COMMIT_DATA)
 def test_with_commits(path_to_repo, filepath, from_commit, to_commit, expected):
     metric = ContributorsCount(path_to_repo=path_to_repo,
                                from_commit=from_commit,
@@ -20,12 +20,12 @@ def test_with_commits(path_to_repo, filepath, from_commit, to_commit, expected):
     filepath = str(Path(filepath))
     assert count[filepath] == expected
 
-TEST_DATA = [
+TEST_DATE_DATA = [
    ('test-repos/pydriller', 'pydriller/git_repository.py', datetime(2019, 12, 17), datetime(2019, 12, 24), 2),
    ('test-repos/pydriller', 'domain/modification.py', datetime(2018, 3, 21), datetime(2018, 3, 27), 1)
 ]
 
-@pytest.mark.parametrize('path_to_repo, filepath, since, to, expected', TEST_DATA)
+@pytest.mark.parametrize('path_to_repo, filepath, since, to, expected', TEST_DATE_DATA)
 def test_with_dates(path_to_repo, filepath, since, to, expected):
     metric = ContributorsCount(path_to_repo=path_to_repo,
                                since=since,

--- a/tests/metrics/process/test_contributors_experience_count.py
+++ b/tests/metrics/process/test_contributors_experience_count.py
@@ -6,13 +6,13 @@ import pytest
 from pydriller.metrics.process.contributors_experience import \
     ContributorsExperience
 
-TEST_DATA = [
+TEST_COMMIT_DATA = [
    ('test-repos/pydriller', 'domain/modification.py', 'fdf671856b260aca058e6595a96a7a0fba05454b', 'ab36bf45859a210b0eae14e17683f31d19eea041', 100.0),
    ('test-repos/pydriller', 'pydriller/git_repository.py', 'e9854bbea1cb7b7f06cbb559f7b06724d11ae1e5', 'e9854bbea1cb7b7f06cbb559f7b06724d11ae1e5', 100.0),
    ('test-repos/pydriller', 'pydriller/git_repository.py', 'e9854bbea1cb7b7f06cbb559f7b06724d11ae1e5', '9d0924301e4fae00eea6d00945bf834455e9a2a6', round(100*28/30, 2))
 ]
 
-@pytest.mark.parametrize('path_to_repo, filepath, from_commit, to_commit, expected', TEST_DATA)
+@pytest.mark.parametrize('path_to_repo, filepath, from_commit, to_commit, expected', TEST_COMMIT_DATA)
 def test_with_commits(path_to_repo, filepath, from_commit, to_commit, expected):
     metric = ContributorsExperience(path_to_repo=path_to_repo,
                                     from_commit=from_commit,
@@ -22,13 +22,13 @@ def test_with_commits(path_to_repo, filepath, from_commit, to_commit, expected):
     assert count[filepath] == expected
 
 
-TEST_DATA = [
+TEST_DATE_DATA = [
    ('test-repos/pydriller', 'domain/modification.py', datetime(2018, 3, 21), datetime(2018, 3, 23), 100.0),
    ('test-repos/pydriller', 'pydriller/git_repository.py', datetime(2018, 8, 1), datetime(2018, 8, 2), 100.0),
    ('test-repos/pydriller', 'pydriller/git_repository.py',  datetime(2018, 7, 23), datetime(2018, 8, 2), round(100*28/30, 2))
 ]
 
-@pytest.mark.parametrize('path_to_repo, filepath, since, to, expected', TEST_DATA)
+@pytest.mark.parametrize('path_to_repo, filepath, since, to, expected', TEST_DATE_DATA)
 def test_with_dates(path_to_repo, filepath, since, to, expected):
     metric = ContributorsExperience(path_to_repo=path_to_repo,
                                     since=since,

--- a/tests/metrics/process/test_history_complexity_count.py
+++ b/tests/metrics/process/test_history_complexity_count.py
@@ -4,13 +4,13 @@ from datetime import datetime
 import pytest
 from pydriller.metrics.process.history_complexity import HistoryComplexity
 
-TEST_DATA = [
+TEST_COMMIT_DATA = [
     ('test-repos/pydriller', 'scm/git_repository.py', '90ca34ebfe69629cb7f186a1582fc38a73cc572e', '90ca34ebfe69629cb7f186a1582fc38a73cc572e', 40.49),
     ('test-repos/pydriller', 'scm/git_repository.py', '71e053f61fc5d31b3e31eccd9c79df27c31279bf', '90ca34ebfe69629cb7f186a1582fc38a73cc572e', 47.05),
     ('https://github.com/geerlingguy/ansible-role-solr', 'tasks/main.yml', '7fb350c30be1124b51aab4a88352428e0a853b9a', '678429591513fe86045e892a1da680c8ac36e00f', .0)
 ]
 
-@pytest.mark.parametrize('path_to_repo, filepath, from_commit, to_commit, expected', TEST_DATA)
+@pytest.mark.parametrize('path_to_repo, filepath, from_commit, to_commit, expected', TEST_COMMIT_DATA)
 def test_with_commits(path_to_repo, filepath, from_commit, to_commit, expected):
     metric = HistoryComplexity(path_to_repo=path_to_repo,
                                from_commit=from_commit,
@@ -21,12 +21,12 @@ def test_with_commits(path_to_repo, filepath, from_commit, to_commit, expected):
     assert count[filepath] == expected
 
 
-TEST_DATA = [
+TEST_DATE_DATA = [
     ('test-repos/pydriller', 'scm/git_repository.py', datetime(2018, 3, 22, 11, 30), datetime(2018, 3, 23), 40.49),
     ('test-repos/pydriller', 'scm/git_repository.py', datetime(2018, 3, 22, 11, 30), datetime(2018, 3, 27), 47.05),
 ]
 
-@pytest.mark.parametrize('path_to_repo, filepath, since, to, expected', TEST_DATA)
+@pytest.mark.parametrize('path_to_repo, filepath, since, to, expected', TEST_DATE_DATA)
 def test_with_dates(path_to_repo, filepath, since, to, expected):
     metric = HistoryComplexity(path_to_repo=path_to_repo,
                                since=since,

--- a/tests/metrics/process/test_hunks_count.py
+++ b/tests/metrics/process/test_hunks_count.py
@@ -5,13 +5,13 @@ import pytest
 
 from pydriller.metrics.process.hunks_count import HunksCount
 
-TEST_DATA = [
+TEST_COMMIT_DATA = [
     ('test-repos/pydriller', 'scm/git_repository.py', '71e053f61fc5d31b3e31eccd9c79df27c31279bf', '71e053f61fc5d31b3e31eccd9c79df27c31279bf', 8),
     ('test-repos/pydriller', 'scm/git_repository.py', 'ab36bf45859a210b0eae14e17683f31d19eea041', '71e053f61fc5d31b3e31eccd9c79df27c31279bf', 3),
     ('test-repos/pydriller', 'domain/modification.py', 'ab36bf45859a210b0eae14e17683f31d19eea041', 'fdf671856b260aca058e6595a96a7a0fba05454b', 1)
 ]
 
-@pytest.mark.parametrize('path_to_repo, filepath, from_commit, to_commit, expected', TEST_DATA)
+@pytest.mark.parametrize('path_to_repo, filepath, from_commit, to_commit, expected', TEST_COMMIT_DATA)
 def test_with_commits(path_to_repo, filepath, from_commit, to_commit, expected):
     metric = HunksCount(path_to_repo=path_to_repo,
                         from_commit=from_commit,
@@ -21,13 +21,13 @@ def test_with_commits(path_to_repo, filepath, from_commit, to_commit, expected):
     filepath = str(Path(filepath))
     assert count[filepath] == expected
 
-TEST_DATA = [
+TEST_DATE_DATA = [
     ('test-repos/pydriller', 'scm/git_repository.py', datetime(2018, 3, 26), datetime(2018, 3, 27), 8),
     ('test-repos/pydriller', 'scm/git_repository.py', datetime(2018, 3, 21), datetime(2018, 3, 27), 3),
     ('test-repos/pydriller', 'domain/modification.py', datetime(2018, 3, 21), datetime(2018, 3, 22, 23), 1)
 ]
 
-@pytest.mark.parametrize('path_to_repo, filepath, since, to, expected', TEST_DATA)
+@pytest.mark.parametrize('path_to_repo, filepath, since, to, expected', TEST_DATE_DATA)
 def test_with_dates(path_to_repo, filepath, since, to, expected):
     metric = HunksCount(path_to_repo=path_to_repo,
                         since=since,

--- a/tests/metrics/process/test_lines_added.py
+++ b/tests/metrics/process/test_lines_added.py
@@ -5,12 +5,12 @@ import pytest
 
 from pydriller.metrics.process.lines_count import LinesCount
 
-TEST_DATA = [
+TEST_COMMIT_DATA = [
    ('test-repos/pydriller', '.gitignore', 'ab36bf45859a210b0eae14e17683f31d19eea041', 'ab36bf45859a210b0eae14e17683f31d19eea041', 197, 197, 197),
    ('test-repos/pydriller', 'domain/modification.py', 'ab36bf45859a210b0eae14e17683f31d19eea041', '71e053f61fc5d31b3e31eccd9c79df27c31279bf', 61, 48, 20)
 ]
 
-@pytest.mark.parametrize('path_to_repo, filepath, from_commit, to_commit, expected_count, expected_max, expected_avg', TEST_DATA)
+@pytest.mark.parametrize('path_to_repo, filepath, from_commit, to_commit, expected_count, expected_max, expected_avg', TEST_COMMIT_DATA)
 def test_with_commits(path_to_repo, filepath, from_commit, to_commit, expected_count, expected_max, expected_avg):
     metric = LinesCount(path_to_repo=path_to_repo,
                         from_commit=from_commit,
@@ -26,12 +26,12 @@ def test_with_commits(path_to_repo, filepath, from_commit, to_commit, expected_c
     assert actual_max[filepath] == expected_max
     assert actual_avg[filepath] == expected_avg
 
-TEST_DATA = [
+TEST_DATE_DATA = [
    ('test-repos/pydriller', '.gitignore', datetime(2018, 3, 21), datetime(2018, 3, 22), 197, 197, 197),
    ('test-repos/pydriller', 'domain/modification.py', datetime(2018, 3, 21), datetime(2018, 3, 27), 61, 48, 20)
 ]
 
-@pytest.mark.parametrize('path_to_repo, filepath, since, to, expected_count, expected_max, expected_avg', TEST_DATA)
+@pytest.mark.parametrize('path_to_repo, filepath, since, to, expected_count, expected_max, expected_avg', TEST_DATE_DATA)
 def test_with_dates(path_to_repo, filepath, since, to, expected_count, expected_max, expected_avg):
     metric = LinesCount(path_to_repo=path_to_repo,
                         since=since,

--- a/tests/metrics/process/test_lines_count.py
+++ b/tests/metrics/process/test_lines_count.py
@@ -5,12 +5,12 @@ import pytest
 
 from pydriller.metrics.process.lines_count import LinesCount
 
-TEST_DATA = [
+TEST_COMMIT_DATA = [
    ('test-repos/pydriller', '.gitignore', 'ab36bf45859a210b0eae14e17683f31d19eea041', 'ab36bf45859a210b0eae14e17683f31d19eea041', 197),
    ('test-repos/pydriller', 'domain/modification.py', 'ab36bf45859a210b0eae14e17683f31d19eea041', '71e053f61fc5d31b3e31eccd9c79df27c31279bf', 65)
 ]
 
-@pytest.mark.parametrize('path_to_repo, filepath, from_commit, to_commit, expected_count', TEST_DATA)
+@pytest.mark.parametrize('path_to_repo, filepath, from_commit, to_commit, expected_count', TEST_COMMIT_DATA)
 def test_with_commits(path_to_repo, filepath, from_commit, to_commit, expected_count):
     metric = LinesCount(path_to_repo=path_to_repo,
                         from_commit=from_commit,
@@ -21,12 +21,12 @@ def test_with_commits(path_to_repo, filepath, from_commit, to_commit, expected_c
 
     assert actual_count[filepath] == expected_count
 
-TEST_DATA = [
+TEST_DATE_DATA = [
    ('test-repos/pydriller', '.gitignore', datetime(2018, 3, 21), datetime(2018, 3, 22), 197),
    ('test-repos/pydriller', 'domain/modification.py', datetime(2018, 3, 21), datetime(2018, 3, 27), 65)
 ]
 
-@pytest.mark.parametrize('path_to_repo, filepath, since, to, expected_count', TEST_DATA)
+@pytest.mark.parametrize('path_to_repo, filepath, since, to, expected_count', TEST_DATE_DATA)
 def test_with_dates(path_to_repo, filepath, since, to, expected_count):
     metric = LinesCount(path_to_repo=path_to_repo,
                         since=since,

--- a/tests/metrics/process/test_lines_removed.py
+++ b/tests/metrics/process/test_lines_removed.py
@@ -5,12 +5,12 @@ import pytest
 
 from pydriller.metrics.process.lines_count import LinesCount
 
-TEST_DATA = [
+TEST_COMMIT_DATA = [
    ('test-repos/pydriller', '.gitignore', 'ab36bf45859a210b0eae14e17683f31d19eea041', 'ab36bf45859a210b0eae14e17683f31d19eea041', 0, 0, 0),
    ('test-repos/pydriller', 'domain/modification.py', 'ab36bf45859a210b0eae14e17683f31d19eea041', '71e053f61fc5d31b3e31eccd9c79df27c31279bf', 4, 3, 1)
 ]
 
-@pytest.mark.parametrize('path_to_repo, filepath, from_commit, to_commit, expected_count, expected_max, expected_avg', TEST_DATA)
+@pytest.mark.parametrize('path_to_repo, filepath, from_commit, to_commit, expected_count, expected_max, expected_avg', TEST_COMMIT_DATA)
 def test_with_commits(path_to_repo, filepath, from_commit, to_commit, expected_count, expected_max, expected_avg):
     metric = LinesCount(path_to_repo=path_to_repo,
                         from_commit=from_commit,
@@ -26,12 +26,12 @@ def test_with_commits(path_to_repo, filepath, from_commit, to_commit, expected_c
     assert actual_max[filepath] == expected_max
     assert actual_avg[filepath] == expected_avg
 
-TEST_DATA = [
+TEST_DATE_DATA = [
    ('test-repos/pydriller', '.gitignore', datetime(2018, 3, 21), datetime(2018, 3, 22), 0, 0, 0),
    ('test-repos/pydriller', 'domain/modification.py', datetime(2018, 3, 21), datetime(2018, 3, 27), 4, 3, 1)
 ]
 
-@pytest.mark.parametrize('path_to_repo, filepath, since, to, expected_count, expected_max, expected_avg', TEST_DATA)
+@pytest.mark.parametrize('path_to_repo, filepath, since, to, expected_count, expected_max, expected_avg', TEST_DATE_DATA)
 def test_with_dates(path_to_repo, filepath, since, to, expected_count, expected_max, expected_avg):
     metric = LinesCount(path_to_repo=path_to_repo,
                         since=since,

--- a/tests/metrics/process/test_minor_contributors_count.py
+++ b/tests/metrics/process/test_minor_contributors_count.py
@@ -5,13 +5,13 @@ import pytest
 
 from pydriller.metrics.process.contributors_count import ContributorsCount
 
-TEST_DATA = [
+TEST_COMMIT_DATA = [
    ('test-repos/pydriller', 'pydriller/git_repository.py', 'e9854bbea1cb7b7f06cbb559f7b06724d11ae1e5', 'e9854bbea1cb7b7f06cbb559f7b06724d11ae1e5', 0),
    ('test-repos/pydriller', 'pydriller/git_repository.py', 'e9854bbea1cb7b7f06cbb559f7b06724d11ae1e5', 'ab36bf45859a210b0eae14e17683f31d19eea041', 1),
    ('test-repos/pydriller', 'pydriller/git_repository.py', '4af3839eb5ea5969f42142529a7a5526739fa570', 'ab36bf45859a210b0eae14e17683f31d19eea041', 2)
 ]
 
-@pytest.mark.parametrize('path_to_repo, filepath, from_commit, to_commit, expected', TEST_DATA)
+@pytest.mark.parametrize('path_to_repo, filepath, from_commit, to_commit, expected', TEST_COMMIT_DATA)
 def test_with_commits(path_to_repo, filepath, from_commit, to_commit, expected):
     metric = ContributorsCount(path_to_repo=path_to_repo,
                                from_commit=from_commit,
@@ -22,13 +22,13 @@ def test_with_commits(path_to_repo, filepath, from_commit, to_commit, expected):
     assert count[filepath] == expected
 
 
-TEST_DATA = [
+TEST_DATE_DATA = [
    ('test-repos/pydriller', 'pydriller/git_repository.py', datetime(2018, 8, 1), datetime(2018, 8, 2), 0),
    ('test-repos/pydriller', 'pydriller/git_repository.py', datetime(2018, 3, 21), datetime(2018, 8, 2), 1),
    ('test-repos/pydriller', 'pydriller/git_repository.py', datetime(2018, 3, 21), datetime(2019, 1, 14, 10), 2)
 ]
 
-@pytest.mark.parametrize('path_to_repo, filepath, since, to, expected', TEST_DATA)
+@pytest.mark.parametrize('path_to_repo, filepath, since, to, expected', TEST_DATE_DATA)
 def test_with_dates(path_to_repo, filepath, since, to, expected):
     metric = ContributorsCount(path_to_repo=path_to_repo,
                                since=since,

--- a/tests/test_dmm.py
+++ b/tests/test_dmm.py
@@ -99,8 +99,7 @@ def commit_by_msg(repo: GitRepository, msg: str) -> Commit:
     for commit in repo.get_list_commits():
         if commit.msg == msg:
             return commit
-    logging.warning('cannot find commit with msg "%s"', msg)
-    return None
+    raise Exception('cannot find commit with msg {}'.format(msg))
 
 @pytest.mark.parametrize('msg,dmm', UNIT_SIZE_TEST_DATA)
 def test_dmm_unit_size(repo: GitRepository, msg: str, dmm: float):


### PR DESCRIPTION
Simple resolution for all open mypy issues, as I was listening to a talk about types in Python.

With this PR we have:

    $ mypy --ignore-missing-imports pydriller/ tests/
    Success: no issues found in 47 source files

Main issues I fixed:

- Added / fixed a few type annotations
- Made `Optional[int]` explicit in `commit.py`, adding `assert` statements when certain that the value is not `None` (e7e386eab32fd44db07290fc685b14015e5cea06)
- Avoided reusing the same variable with different types (TEST_DATA in a7b29f804238003b05113845e9f949c56647434a, and in the RepositoryMining constructor in 5de621b2c450f9fcb5306052cc06acaf75665353)
