### PR TITLE
Fix #145

### DIFF
--- a/pydriller/domain/commit.py
+++ b/pydriller/domain/commit.py
@@ -664,7 +664,12 @@ class Commit:
     def _get_branches(self):
         c_git = Git(str(self._conf.get('path_to_repo')))
         branches = set()
-        for branch in set(c_git.branch('--contains', self.hash).split('\n')):
+        args = ['--contains', self.hash]
+        if self._conf.get("include_remotes"):
+            args = ["-r"] + args
+        if self._conf.get("include_refs"):
+            args = ["-a"] + args
+        for branch in set(c_git.branch(*args).split('\n')):
             branches.add(branch.strip().replace('* ', ''))
         return branches
 


### PR DESCRIPTION
When the include_remotes and include_refs are added to the RepositoryMining, we need to pass those to the branch lookup too.