### PR TITLE
Added insertions/deletions/lines/files properities for easy commit info collection in commit.py

### DIFF
--- a/pydriller/domain/commit.py
+++ b/pydriller/domain/commit.py
@@ -554,6 +554,33 @@ class Commit:
         return len(self._c_object.parents) > 1
 
     @property
+    def insertions(self) -> str:
+        """
+        Return the insertion lines of the commit.
+
+        :return: str insertion lines
+        """
+        return self._c_object.stats.total["insertions"]
+
+    @property
+    def deletions(self) -> str:
+        """
+        Return the deletion lines of the commit.
+
+        :return: str deletion lines
+        """
+        return self._c_object.stats.total["deletions"]
+
+    @property
+    def lines(self) -> str:
+        """
+        Return the deletion lines of the commit.
+
+        :return: str insertion + deletion lines
+        """
+        return self._c_object.stats.total["lines"]
+
+    @property
     def modifications(self) -> List[Modification]:
         """
         Return a list of modified files. The list is empty if the commit is

--- a/pydriller/domain/commit.py
+++ b/pydriller/domain/commit.py
@@ -554,29 +554,29 @@ class Commit:
         return len(self._c_object.parents) > 1
 
     @property
-    def insertions(self) -> str:
+    def insertions(self) -> int:
         """
         Return the insertion lines of the commit.
 
-        :return: str insertion lines
+        :return: int insertion lines
         """
         return self._c_object.stats.total["insertions"]
 
     @property
-    def deletions(self) -> str:
+    def deletions(self) -> int:
         """
         Return the deletion lines of the commit.
 
-        :return: str deletion lines
+        :return: int deletion lines
         """
         return self._c_object.stats.total["deletions"]
 
     @property
-    def lines(self) -> str:
+    def lines(self) -> int:
         """
         Return the deletion lines of the commit.
 
-        :return: str insertion + deletion lines
+        :return: int insertion + deletion lines
         """
         return self._c_object.stats.total["lines"]
 

--- a/pydriller/domain/commit.py
+++ b/pydriller/domain/commit.py
@@ -574,7 +574,7 @@ class Commit:
     @property
     def lines(self) -> int:
         """
-        Return the deletion lines of the commit.
+        Return the total lines of the commit.
 
         :return: int insertion + deletion lines
         """
@@ -583,9 +583,9 @@ class Commit:
     @property
     def files(self) -> int:
         """
-        Return the deletion lines of the commit.
+        Return the modified files of the commit.
 
-        :return: str insertion + deletion lines
+        :return: int modified files number
         """
         return len(self._c_object.stats.files)
 

--- a/pydriller/domain/commit.py
+++ b/pydriller/domain/commit.py
@@ -587,7 +587,7 @@ class Commit:
 
         :return: int modified files number
         """
-        return len(self._c_object.stats.files)
+        return self._c_object.stats.total["files"]
 
     @property
     def modifications(self) -> List[Modification]:

--- a/pydriller/domain/commit.py
+++ b/pydriller/domain/commit.py
@@ -581,6 +581,15 @@ class Commit:
         return self._c_object.stats.total["lines"]
 
     @property
+    def files(self) -> int:
+        """
+        Return the deletion lines of the commit.
+
+        :return: str insertion + deletion lines
+        """
+        return len(self._c_object.stats.files)
+
+    @property
     def modifications(self) -> List[Modification]:
         """
         Return a list of modified files. The list is empty if the commit is

--- a/tests/test_git_repository.py
+++ b/tests/test_git_repository.py
@@ -72,6 +72,10 @@ def test_get_commit(repo: GitRepository):
     assert len(c.modifications) == 1
     assert c.msg == 'Ooops file2'
     assert c.in_main_branch is True
+    assert c.insertions == 4
+    assert c.deletions == 0
+    assert c.lines == 4
+    assert c.files == 1
 
 
 @pytest.mark.parametrize('repo', ['test-repos/detached_head/'], indirect=True)


### PR DESCRIPTION
Added insertions/deletions/lines properities for easy commit info collection

From phrase the gitpython classgit.util.Stats(total, files) it could give the data we need
https://gitpython.readthedocs.io/en/stable/reference.html?highlight=stats.total#git.util.Stats
