### PR TITLE
Pydriller2 - Multithreading

### DIFF
--- a/pydriller/git_repository.py
+++ b/pydriller/git_repository.py
@@ -56,6 +56,9 @@ class GitRepository:
         self._conf = conf
         self._conf.set_value("main_branch", None)  # init main_branch to None
 
+        # Initialize repository
+        self._open_repository()
+
     @property
     def repo(self) -> Repo:
         """

--- a/pydriller/repository_mining.py
+++ b/pydriller/repository_mining.py
@@ -224,7 +224,7 @@ class RepositoryMining:
 
                 chunks = self._split_in_chunks(commits_list, self._conf.get("num_workers"))
                 with concurrent.futures.ThreadPoolExecutor(max_workers=self._conf.get("num_workers")) as executor:
-                    jobs = {executor.submit(self.iter_commits, chunk): chunk for chunk in chunks}
+                    jobs = {executor.submit(self._iter_commits, chunk): chunk for chunk in chunks}
 
                     parallel_results = []
                     for job in concurrent.futures.as_completed(jobs):
@@ -234,7 +234,7 @@ class RepositoryMining:
                     for result in parallel_results:
                         return result
 
-    def iter_commits(self, commits_list: List[Commit]) -> Commit:
+    def _iter_commits(self, commits_list: List[Commit]) -> Commit:
         for commit in commits_list:
             logger.info('Commit #%s in %s from %s', commit.hash, commit.committer_date, commit.author.name)
 
@@ -244,7 +244,8 @@ class RepositoryMining:
 
             yield commit
 
-    def _split_in_chunks(self, full_list: List[Commit], num_workers: int) -> List[List[Commit]]:
+    @staticmethod
+    def _split_in_chunks(full_list: List[Commit], num_workers: int) -> List[List[Commit]]:
         """
         Given the list of commits return chunks of commits based on the number of workers.
 

--- a/pydriller/repository_mining.py
+++ b/pydriller/repository_mining.py
@@ -226,13 +226,8 @@ class RepositoryMining:
                 with concurrent.futures.ThreadPoolExecutor(max_workers=self._conf.get("num_workers")) as executor:
                     jobs = {executor.submit(self._iter_commits, chunk): chunk for chunk in chunks}
 
-                    parallel_results = []
                     for job in concurrent.futures.as_completed(jobs):
-                        result = job.result()
-                        parallel_results.append(result)
-
-                    for result in parallel_results:
-                        return result
+                        return job.result()
 
     def _iter_commits(self, commits_list: List[Commit]) -> Commit:
         for commit in commits_list:


### PR DESCRIPTION
Started working on Pydriller2.0.
First off is multithreading. This seems to substantially decrease the time to analyze a repo.
The following code:
```
start = datetime.now()
for commit in RepositoryMining("https://github.com/apache/hadoop").traverse_commits():
    for modified_file in commit.modifications:
        d = modified_file.diff

end = datetime.now()
print(f"Finished in {end - start}")
```
goes from 11.04 minutes to 1.46 minute! 