### PR TITLE
Catch specific exception with malformed repo url

### DIFF
--- a/pydriller/repository.py
+++ b/pydriller/repository.py
@@ -271,6 +271,11 @@ class Repository:
             last_suffix_index = len(url)
 
         if last_slash_index < 0 or last_suffix_index <= last_slash_index:
-            raise Exception("Badly formatted url {}".format(url))
+            raise MalformedUrl("Badly formatted url {}".format(url))
 
         return url[last_slash_index + 1:last_suffix_index]
+
+
+class MalformedUrl(Exception):
+    def __init__(self, message):
+        super().__init__(message)

--- a/tests/test_repository_mining.py
+++ b/tests/test_repository_mining.py
@@ -5,6 +5,7 @@ import pytest
 import sys
 
 from pydriller import Repository, Git
+from pydriller.repository import MalformedUrl
 
 logging.basicConfig(format='%(asctime)s - %(levelname)s - %(message)s',
                     level=logging.INFO)
@@ -38,6 +39,12 @@ def test_no_url():
 def test_badly_formatted_repo_url():
     with pytest.raises(Exception):
         list(Repository(path_to_repo=set('repo')).traverse_commits())
+
+
+# It should fail when URL is malformed
+def test_malformed_url():
+    with pytest.raises(MalformedUrl):
+        list(Repository("https://badurl.git/").traverse_commits())
 
 
 @pytest.mark.parametrize('repo,expected', [


### PR DESCRIPTION
First of all thanks for the great library. I am currently developing a [streamlit][1] dashboard that computes some stats from a commit history.

It would be probably more sensible to catch a more specific exception when a user inputs wrongly formatted urls instead of a catch all `Exception`. Needless to say, if you find this relevant, feel free to rename the class as you best see fit.

Thanks again.

[1]: https://streamlit.io