### PR TITLE
Workaround Windows Temp File Cleanup Error

### DIFF
--- a/pydriller/repository.py
+++ b/pydriller/repository.py
@@ -19,6 +19,7 @@ This module includes 1 class, Repository, main class of PyDriller.
 import logging
 import math
 import os
+import sys
 import shutil
 import tempfile
 import concurrent.futures
@@ -204,6 +205,14 @@ class Repository:
                 # git directories because of read-only files.
                 # In this case, just ignore the errors.
                 shutil.rmtree(self._tmp_dir.name, ignore_errors=True)
+            except OSError as e:
+                # Another cleanup error happens on Windows with errno 145
+                # Manually remove files
+                # Otherwise, rethrow errors.
+                if sys.platform == "win32" and e.errno == 145:
+                    shutil.rmtree(self._tmp_dir.name, ignore_errors=True)
+                else:
+                    raise(e)
 
     def traverse_commits(self) -> Generator[Commit, None, None]:
         """

--- a/pydriller/repository.py
+++ b/pydriller/repository.py
@@ -209,7 +209,7 @@ class Repository:
                 # Another cleanup error happens on Windows with errno 145
                 # Manually remove files
                 # Otherwise, rethrow errors.
-                if sys.platform == "win32" and e.errno == 145:
+                if sys.platform == "win32" and e.winerror == 145:
                     shutil.rmtree(self._tmp_dir.name, ignore_errors=True)
                 else:
                     raise(e)

--- a/pydriller/repository.py
+++ b/pydriller/repository.py
@@ -205,12 +205,10 @@ class Repository:
                 # git directories because of read-only files.
                 # In this case, just ignore the errors.
                 shutil.rmtree(self._tmp_dir.name, ignore_errors=True)
-            except OSError as e:
-                # Another cleanup error happens on Windows with errno 145
+            except (PermissionError, OSError) as e:
+                # On Windows there might be cleanup errors.
                 # Manually remove files
-                # Otherwise, rethrow errors.
-                if sys.platform == "win32" and e.winerror == 145:
-                    shutil.rmtree(self._tmp_dir.name, ignore_errors=True)
+                shutil.rmtree(self._tmp_dir.name, ignore_errors=True)
                 else:
                     raise(e)
 

--- a/pydriller/repository.py
+++ b/pydriller/repository.py
@@ -199,11 +199,6 @@ class Repository:
             assert self._tmp_dir is not None
             try:
                 self._tmp_dir.cleanup()
-            except PermissionError:
-                # on Windows, Python 3.5, 3.6, 3.7 are not able to delete
-                # git directories because of read-only files.
-                # In this case, just ignore the errors.
-                shutil.rmtree(self._tmp_dir.name, ignore_errors=True)
             except (PermissionError, OSError):
                 # On Windows there might be cleanup errors.
                 # Manually remove files

--- a/pydriller/repository.py
+++ b/pydriller/repository.py
@@ -19,7 +19,6 @@ This module includes 1 class, Repository, main class of PyDriller.
 import logging
 import math
 import os
-import sys
 import shutil
 import tempfile
 import concurrent.futures
@@ -209,8 +208,6 @@ class Repository:
                 # On Windows there might be cleanup errors.
                 # Manually remove files
                 shutil.rmtree(self._tmp_dir.name, ignore_errors=True)
-                else:
-                    raise(e)
 
     def traverse_commits(self) -> Generator[Commit, None, None]:
         """

--- a/pydriller/repository.py
+++ b/pydriller/repository.py
@@ -204,7 +204,7 @@ class Repository:
                 # git directories because of read-only files.
                 # In this case, just ignore the errors.
                 shutil.rmtree(self._tmp_dir.name, ignore_errors=True)
-            except (PermissionError, OSError) as e:
+            except (PermissionError, OSError):
                 # On Windows there might be cleanup errors.
                 # Manually remove files
                 shutil.rmtree(self._tmp_dir.name, ignore_errors=True)


### PR DESCRIPTION
This is just an ugly workaround to avoid errors on Windows when cleaning up temp files. The fault is probably on the Windows side due to its annoying file handling.

A more elegant way is definitely desired.