### PR TITLE
Adding ModifiedFile.content and deprecating ModifiedFile.source_code

### DIFF
--- a/tests/test_git_repository.py
+++ b/tests/test_git_repository.py
@@ -13,13 +13,13 @@
 # limitations under the License.
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
+from warnings import catch_warnings
 
 import pytest
 from git import Git as PyGit
 
 from pydriller.domain.commit import ModificationType
 from pydriller.git import Git
-
 
 @pytest.fixture
 def repo(request):
@@ -243,7 +243,12 @@ def test_should_detail_a_commit(repo: Git):
 
     assert commit.modified_files[0].new_path == "Matricula.java"
     assert commit.modified_files[0].diff.startswith("@@ -0,0 +1,62 @@\n+package model;") is True
-    assert commit.modified_files[0].source_code.startswith("package model;") is True
+    assert commit.modified_files[0].content.startswith("package model;") is True
+    
+    with catch_warnings(record=True) as w:
+        assert commit.modified_files[0].source_code.startswith("package model;") is True
+        assert len(w) == 1
+        assert issubclass(w[0].category, DeprecationWarning)
 
 
 @pytest.mark.parametrize('repo', ['test-repos/branches_merged'], indirect=True)

--- a/tests/test_git_repository.py
+++ b/tests/test_git_repository.py
@@ -21,6 +21,7 @@ from git import Git as PyGit
 from pydriller.domain.commit import ModificationType
 from pydriller.git import Git
 
+
 @pytest.fixture
 def repo(request):
     gr = Git(request.param)
@@ -244,7 +245,7 @@ def test_should_detail_a_commit(repo: Git):
     assert commit.modified_files[0].new_path == "Matricula.java"
     assert commit.modified_files[0].diff.startswith("@@ -0,0 +1,62 @@\n+package model;") is True
     assert commit.modified_files[0].content.startswith("package model;") is True
-    
+
     with catch_warnings(record=True) as w:
         assert commit.modified_files[0].source_code.startswith("package model;") is True
         assert len(w) == 1


### PR DESCRIPTION
This pull request should address #216, open to discuss modifications and refactoring operations.

I believe `source_code` is a core property used by many and therefore should not be refactored to `content` any time soon. Instead, it should be deprecated and then removed in a future version of PyDriller. Therefore, this pull request addresses issue #216 by adding the class variables `content` and `content_before` that behave exactly like `source_code` and `source_code_before`; the latter have been also translated to properties to warn the user about their deprecation. 

Test cases using property `source_code` and `source_code_before`. Checked :ballot_box_with_check:  if modified for DeprecationWarning and testing the new property `content`:

- [x] **tests/test_commit/test_source_code_before()**
- [x] **tests/test_commit/test_source_code_before_complete()**
- [x] **tests/test_commit/test_filename()**
- [x] **tests/test_commit/test_metrics_python()**
- [x] **tests/test_commit/test_metrics_cpp()**
- [x] **tests/test_commit/test_metrics_java()**
- [x] **tests/test_commit/test_metrics_not_supported_file()**
- [x] **tests/test_git_repository/test_should_detail_a_commit()**

Methods in `ModifiedFile` that use `source_code` or `source_code_before`. Checked :ballot_box_with_check:  if modified to warn deprecation and to include the new property `content`:

- [x] __init__()
- `self.source_code` has been renamed to `self.__source_code` to handle DeprecationWarning in a new method/property `source_code()`.
- `self.source_code_before` has been renamed to `self.__source_code_before` to handle DeprecationWarning in a new method/property `source_code_before()`.
- Added `self.content` and `self.content_before`.
- [x] __hash__()
- `self.source_code` replaced by `self.content` to generate hashable string. 
- [ ] **_calculate_metrics()**
- Refactor `source_code` and `source_code_before` to `content` and `content_before`.


Methods in `Commit` that use `source_code` or `source_code_before`. 
- [x] **_parse_diff()**
- Added key:value pairs `content_before` and `content` to the `diff_and_sc` dictionary that is passed to ModifiedFile.

Future refactoring:
- [ ] Rename `diff_and_sc -> diff_and_content` in commit.py.
 
