### PR TITLE
Stop packaging tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     author='Davide Spadini',
     author_email='spadini.davide@gmail.com',
     version=get_version(),
-    packages=find_packages('.'),
+    packages=find_packages('.', exclude=['tests*']),
     url='https://github.com/ishepard/pydriller',
     license='Apache License',
     package_dir={'pydriller': 'pydriller'},


### PR DESCRIPTION
Tests of pydriller are packaged together with pydriller and are installed to target systems next to pydriller thus polluting site-packages with a `tests` module. The `tests` module (and all submodules) is (/are) excluded now.