### PR TITLE
Fix multithread memory consumption

### DIFF
--- a/pydriller/domain/commit.py
+++ b/pydriller/domain/commit.py
@@ -506,9 +506,6 @@ class Commit:
         :param conf: Configuration class
         """
         self._c_object = commit
-
-        self._modified_files: List[ModifiedFile] = []
-        self._branches: Set[str] = set()
         self._conf = conf
 
     def __hash__(self) -> int:
@@ -685,13 +682,6 @@ class Commit:
 
         :return: List[Modification] modifications
         """
-        if not self._modified_files:
-            self._modified_files = self._get_modified_files()
-
-        assert self._modified_files is not None
-        return self._modified_files
-
-    def _get_modified_files(self) -> List[ModifiedFile]:
         options = {}
         if self._conf.get("histogram"):
             options["histogram"] = True
@@ -777,13 +767,6 @@ class Commit:
 
         :return: set(str) branches
         """
-        if not self._branches:
-            self._branches = self._get_branches()
-
-        assert self._branches
-        return self._branches
-
-    def _get_branches(self) -> Set[str]:
         c_git = Git(str(self._conf.get("path_to_repo")))
         branches = set()
         args = ["--contains", self.hash]

--- a/pydriller/repository.py
+++ b/pydriller/repository.py
@@ -236,7 +236,7 @@ class Repository:
                         for commit in job:
                             yield commit
 
-    def _iter_commits(self, commit: List[Commit]) -> Generator[Commit, None, None]:
+    def _iter_commits(self, commit: Commit) -> Generator[Commit, None, None]:
         logger.info(f'Commit #{commit.hash} in {commit.committer_date} from {commit.author.name}')
 
         if self._conf.is_commit_filtered(commit):

--- a/pydriller/repository.py
+++ b/pydriller/repository.py
@@ -230,28 +230,20 @@ class Repository:
                 # Build the arguments to pass to git rev-list.
                 rev, kwargs = self._conf.build_args()
 
-                commits_list = list(git.get_list_commits(rev, **kwargs))
-
-                if not commits_list:
-                    return
-
-                chunks = self._split_in_chunks(commits_list, self._conf.get("num_workers"))
                 with concurrent.futures.ThreadPoolExecutor(max_workers=self._conf.get("num_workers")) as executor:
-                    jobs = {executor.submit(self._iter_commits, chunk): chunk for chunk in chunks}
+                    for job in executor.map(self._iter_commits, git.get_list_commits(rev, **kwargs)):
 
-                    for job in concurrent.futures.as_completed(jobs):
-                        for commit in job.result():
+                        for commit in job:
                             yield commit
 
-    def _iter_commits(self, commits_list: List[Commit]) -> Generator[Commit, None, None]:
-        for commit in commits_list:
-            logger.info(f'Commit #{commit.hash} in {commit.committer_date} from {commit.author.name}')
+    def _iter_commits(self, commit: List[Commit]) -> Generator[Commit, None, None]:
+        logger.info(f'Commit #{commit.hash} in {commit.committer_date} from {commit.author.name}')
 
-            if self._conf.is_commit_filtered(commit):
-                logger.info(f'Commit #{commit.hash} filtered')
-                continue
+        if self._conf.is_commit_filtered(commit):
+            logger.info(f'Commit #{commit.hash} filtered')
+            return
 
-            yield commit
+        yield commit
 
     @staticmethod
     def _split_in_chunks(full_list: List[Commit], num_workers: int) -> List[List[Commit]]:

--- a/tests/test_memory_consumption.py
+++ b/tests/test_memory_consumption.py
@@ -26,23 +26,19 @@ PATH = os.getenv('GITHUB_WORKSPACE')
 
 
 def test_memory(caplog):
-    if not PATH:
-        return
-    path_to_pydriller = Path(PATH) / "pydriller"
-
-    if not path_to_pydriller.exists():
+    if not PATH or not os.path.exists(PATH):
         return
 
     caplog.set_level(logging.WARNING)
-    logging.warning(f"Analyzing path {path_to_pydriller}")
+    logging.warning(f"Analyzing path {PATH}")
     logging.warning("Starting with nothing...")
-    diff_with_nothing, all_commits_with_nothing = mine(str(path_to_pydriller), 0)
+    diff_with_nothing, all_commits_with_nothing = mine(PATH, 0)
 
     logging.warning("Starting with everything...")
-    diff_with_everything, all_commits_with_everything = mine(str(path_to_pydriller), 1)
+    diff_with_everything, all_commits_with_everything = mine(PATH, 1)
 
     logging.warning("Starting with metrics...")
-    diff_with_metrics, all_commits_with_metrics = mine(str(path_to_pydriller), 2)
+    diff_with_metrics, all_commits_with_metrics = mine(PATH, 2)
 
     max_values = [max(all_commits_with_nothing),
                   max(all_commits_with_everything),

--- a/tests/test_memory_consumption.py
+++ b/tests/test_memory_consumption.py
@@ -21,7 +21,7 @@ from pydriller import Repository
 from datetime import datetime
 
 logging.basicConfig(level=logging.WARNING)
-skip_remote = False
+skip_remote = True
 
 
 def test_memory(caplog):

--- a/tests/test_memory_consumption.py
+++ b/tests/test_memory_consumption.py
@@ -26,19 +26,20 @@ PATH = os.getenv('GITHUB_WORKSPACE')
 
 
 def test_memory(caplog):
-    if not PATH or not os.path.exists(PATH):
+    if not PATH:
+        # Check we are on GitHub
         return
 
     caplog.set_level(logging.WARNING)
-    logging.warning(f"Analyzing path {PATH}")
+
     logging.warning("Starting with nothing...")
-    diff_with_nothing, all_commits_with_nothing = mine(PATH, 0)
+    diff_with_nothing, all_commits_with_nothing = mine(0)
 
     logging.warning("Starting with everything...")
-    diff_with_everything, all_commits_with_everything = mine(PATH, 1)
+    diff_with_everything, all_commits_with_everything = mine(1)
 
     logging.warning("Starting with metrics...")
-    diff_with_metrics, all_commits_with_metrics = mine(PATH, 2)
+    diff_with_metrics, all_commits_with_metrics = mine(2)
 
     max_values = [max(all_commits_with_nothing),
                   max(all_commits_with_everything),
@@ -110,13 +111,13 @@ def log(diff_with_nothing, all_commits_with_nothing,
     ))
 
 
-def mine(path_to_pydriller, _type):
+def mine(_type):
     p = psutil.Process(os.getpid())
     dt2 = datetime(2021, 12, 1)
     all_commits = []
 
     start = datetime.now()
-    for commit in Repository(path_to_pydriller,
+    for commit in Repository("https://github.com/ishepard/pydriller.git",
                              to=dt2).traverse_commits():
         memory = p.memory_info()[0] / (2 ** 20)
         all_commits.append(memory)

--- a/tests/test_memory_consumption.py
+++ b/tests/test_memory_consumption.py
@@ -21,7 +21,7 @@ from pydriller import Repository
 from datetime import datetime
 
 logging.basicConfig(level=logging.WARNING)
-skip_remote = True
+skip_remote = False
 
 
 def test_memory(caplog):
@@ -53,15 +53,15 @@ def test_memory(caplog):
             diff_with_nothing.seconds // 3600,
             (diff_with_nothing.seconds % 3600) // 60,
             diff_with_nothing.seconds % 60,
-            578 // diff_with_nothing.seconds if diff_with_nothing.seconds != 0 else 0,
+            1045 // diff_with_nothing.seconds if diff_with_nothing.seconds != 0 else 0,
             diff_with_everything.seconds // 3600,
             (diff_with_everything.seconds % 3600) // 60,
             diff_with_everything.seconds % 60,
-            578 // diff_with_everything.seconds,
+            1045 // diff_with_everything.seconds,
             diff_with_metrics.seconds // 3600,
             (diff_with_metrics.seconds % 3600) // 60,
             diff_with_metrics.seconds % 60,
-            578 // diff_with_metrics.seconds
+            1045 // diff_with_metrics.seconds
         )
     )
 
@@ -75,7 +75,7 @@ def test_memory(caplog):
             diff_with_everything, all_commits_with_everything,
             diff_with_metrics, all_commits_with_metrics)
 
-    assert 578 == len(all_commits_with_nothing) == len(all_commits_with_everything) == len(all_commits_with_metrics)
+    assert 1045 == len(all_commits_with_nothing) == len(all_commits_with_everything) == len(all_commits_with_metrics)
 
 
 def log(diff_with_nothing, all_commits_with_nothing,
@@ -110,7 +110,7 @@ def log(diff_with_nothing, all_commits_with_nothing,
 def mine(_type):
     p = psutil.Process(os.getpid())
     dt1 = datetime(2020, 1, 1)
-    dt2 = datetime(2020, 7, 1)
+    dt2 = datetime(2020, 12, 1)
     all_commits = []
 
     start = datetime.now()

--- a/tests/test_memory_consumption.py
+++ b/tests/test_memory_consumption.py
@@ -14,6 +14,7 @@
 
 import logging
 import os
+from pathlib import Path
 import platform
 import sys
 import psutil
@@ -27,21 +28,21 @@ PATH = os.getenv('GITHUB_WORKSPACE')
 def test_memory(caplog):
     if not PATH:
         return
-    path_to_pydriller = PATH + "/pydriller"
+    path_to_pydriller = Path(PATH) / "pydriller"
 
-    if not os.path.exists(path_to_pydriller):
+    if not path_to_pydriller.exists():
         return
 
     caplog.set_level(logging.WARNING)
-
+    logging.warning(f"Analyzing path {path_to_pydriller}")
     logging.warning("Starting with nothing...")
-    diff_with_nothing, all_commits_with_nothing = mine(path_to_pydriller, 0)
+    diff_with_nothing, all_commits_with_nothing = mine(str(path_to_pydriller), 0)
 
     logging.warning("Starting with everything...")
-    diff_with_everything, all_commits_with_everything = mine(path_to_pydriller, 1)
+    diff_with_everything, all_commits_with_everything = mine(str(path_to_pydriller), 1)
 
     logging.warning("Starting with metrics...")
-    diff_with_metrics, all_commits_with_metrics = mine(path_to_pydriller, 2)
+    diff_with_metrics, all_commits_with_metrics = mine(str(path_to_pydriller), 2)
 
     max_values = [max(all_commits_with_nothing),
                   max(all_commits_with_everything),

--- a/tests/test_memory_consumption.py
+++ b/tests/test_memory_consumption.py
@@ -14,7 +14,6 @@
 
 import logging
 import os
-from pathlib import Path
 import platform
 import sys
 import psutil


### PR DESCRIPTION
When I implemented multithread I did a terrible thing, that was transforming a generator to a list and split it among workers. 
This is not optimal since we load in memory ALL commits, and keep a reference to them, so slowly we end up with a huge amount of RAM usage.

Using executor.map() seems to do the trick, it's similar to .map() but it uses threads instead. The amount of resources used are also way less.