### PR TITLE
Fix calculation of Method.__hash__

### DIFF
--- a/pydriller/domain/commit.py
+++ b/pydriller/domain/commit.py
@@ -101,7 +101,7 @@ class Method:
                 "long_name",
                 self.long_name,
                 "params",
-                (x for x in self.parameters),
+                tuple(x for x in self.parameters),
             )
         )
 


### PR DESCRIPTION
Current version of `Method.__hash__()` passes a generator to the `hash` builtin, which produces a hash value based on the generator address. Although this seems to work on CPython - the address of the generator happens to be the same when called from the set comprehension in `ModifiedFiles.changed_methods` - it is clearly not intended and breaks on other python implementations.