### PR TITLE
Added since_as_filter

### DIFF
--- a/pydriller/repository.py
+++ b/pydriller/repository.py
@@ -43,7 +43,7 @@ class Repository:
 
     def __init__(self, path_to_repo: Union[str, List[str]],
                  single: Optional[str] = None,
-                 since: Optional[datetime] = None, to: Optional[datetime] = None,
+                 since: Optional[datetime] = None, since_as_filter: Optional[datetime] = None, to: Optional[datetime] = None,
                  from_commit: Optional[str] = None, to_commit: Optional[str] = None,
                  from_tag: Optional[str] = None, to_tag: Optional[str] = None,
                  include_refs: bool = False,
@@ -76,6 +76,7 @@ class Repository:
             absolute paths) to the repository(ies) to analyze
         :param str single: hash of a single commit to analyze
         :param datetime since: starting date
+        :param datetime since_as_filter: starting date (scans all commits, does not stop at first commit with date < since_as_filter)
         :param datetime to: ending date
         :param str from_commit: starting commit (only if `since` is None)
         :param str to_commit: ending commit (only if `to` is None)
@@ -119,6 +120,7 @@ class Repository:
             "from_tag": from_tag,
             "to_tag": to_tag,
             "since": since,
+            "since_as_filter": since_as_filter,
             "to": to,
             "single": single,
             "include_refs": include_refs,

--- a/pydriller/utils/conf.py
+++ b/pydriller/utils/conf.py
@@ -65,15 +65,16 @@ class Conf:
 
     def _check_only_one_from_commit(self) -> None:
         if not self.only_one_filter([self.get('since'),
+                                     self.get('since_as_filter'),
                                      self.get('from_commit'),
                                      self.get('from_tag')]):
-            raise Exception('You can only specify one filter between since, from_tag and from_commit')
+            raise Exception('You can only specify one filter between since, since_as_filter, from_tag and from_commit')
 
     def _check_only_one_to_commit(self) -> None:
         if not self.only_one_filter([self.get('to'),
                                      self.get('to_commit'),
                                      self.get('to_tag')]):
-            raise Exception('You can only specify one between since, from_tag and from_commit')
+            raise Exception('You can only specify one between to, to_tag and to_commit')
 
     def sanity_check_filters(self) -> None:
         """
@@ -98,6 +99,7 @@ class Conf:
 
         if self.get('single') is not None:
             if any([self.get('since'),
+                    self.get('since_as_filter'),
                     self.get('to'),
                     self.get('from_commit'),
                     self.get('to_commit'),
@@ -142,7 +144,7 @@ class Conf:
 
     def get_starting_commit(self) -> Optional[List[str]]:
         """
-        Get the starting commit from the 'since', 'from_commit' or 'from_tag'
+        Get the starting commit from the 'from_commit' or 'from_tag'
         filter.
         """
         from_tag = self.get('from_tag')
@@ -199,6 +201,7 @@ class Conf:
         """
         single: str = self.get('single')
         since = self.get('since')
+        since_as_filter = self.get('since_as_filter')
         until = self.get('to')
         from_commit = self.get_starting_commit()
         to_commit = self.get_ending_commit()
@@ -252,6 +255,9 @@ class Conf:
         if since is not None:
             kwargs['since'] = since
 
+        if since_as_filter is not None:
+            kwargs['since_as_filter'] = since_as_filter
+
         if until is not None:
             kwargs['until'] = until
 
@@ -290,6 +296,8 @@ class Conf:
     def _check_timezones(self):
         if self.get('since') is not None:
             self.set_value('since', self._replace_timezone(self.get('since')))
+        if self.get('since_as_filter') is not None:
+            self.set_value('since_as_filter', self._replace_timezone(self.get('since_as_filter')))
         if self.get('to') is not None:
             self.set_value('to', self._replace_timezone(self.get('to')))
 

--- a/tests/integration/test_commit_filters.py
+++ b/tests/integration/test_commit_filters.py
@@ -234,6 +234,18 @@ def test_filepath_with_since():
         since=since).traverse_commits())) == 11
 
 
+def test_since_as_filter():
+    since_as_filter = datetime(2018, 6, 6, 0, 0, 0, tzinfo=timezone.utc)
+
+    assert len(list(Repository(
+        path_to_repo='test-repos/since_as_filter',
+        since=since_as_filter).traverse_commits())) == 3
+
+    assert len(list(Repository(
+        path_to_repo='test-repos/since_as_filter',
+        since_as_filter=since_as_filter).traverse_commits())) == 16
+
+
 def test_filepath_with_rename():
     dt = datetime(2018, 6, 6)
     commits = list(Repository(


### PR DESCRIPTION
Added ```since_as_filter``` so that all commits greater than the ```since_as_filter``` date are considered, even if committer dates are out of order (see https://github.com/ishepard/pydriller/issues/255).