### PR TITLE
Add Mehtod class  doc on API webpage

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -37,7 +37,16 @@ Commit
    :undoc-members:
    :special-members:
    :exclude-members: __dict__, __weakref__, __eq__, __str__, __hash__
+  
+Methods
+----------------
 
+.. automodule:: pydriller.domain.commit.Method
+   :members:
+   :undoc-members:
+   :special-members:
+   :exclude-members: __dict__, __weakref__, __eq__, __str__, __hash__
+   
 Developer
 ----------------
 


### PR DESCRIPTION
I found the doc about Methods class on the API webpage is Missing, when I want to know what information i can get from Methods