### PR TITLE
Improve modified files

### DIFF
--- a/pydriller/domain/commit.py
+++ b/pydriller/domain/commit.py
@@ -197,8 +197,8 @@ class ModifiedFile:
         return ModificationType.UNKNOWN
     
     @property
-    def diff(self) -> Optional[str]:
-        return self._get_decoded_str(self._c_diff.diff)
+    def diff(self) -> str:
+        return self._get_decoded_str(self._c_diff.diff) or ''
     
     def _get_decoded_str(self, diff: Union[str, bytes, None]) -> Optional[str]:
         try:

--- a/pydriller/domain/commit.py
+++ b/pydriller/domain/commit.py
@@ -237,7 +237,7 @@ class ModifiedFile:
         return None
 
     @property
-    def added_lines(self) -> Optional[int]:
+    def added_lines(self) -> int:
         """
         Return the total number of added lines in the file.
 
@@ -250,7 +250,7 @@ class ModifiedFile:
         return added_lines
 
     @property
-    def deleted_lines(self) -> Optional[int]:
+    def deleted_lines(self) -> int:
         """
         Return the total number of deleted lines in the file.
 
@@ -293,7 +293,7 @@ class ModifiedFile:
 
         :return: str filename
         """
-        if self.new_path is not None and str(self.new_path) != "/dev/null":
+        if self.new_path is not None and self.new_path != "/dev/null":
             path = self.new_path
         else:
             assert self.old_path
@@ -343,7 +343,7 @@ class ModifiedFile:
         return self._token_count
 
     @property
-    def diff_parsed(self) -> Optional[Dict[str, List[Tuple[int, str]]]]:
+    def diff_parsed(self) -> Dict[str, List[Tuple[int, str]]]:
         """
         Returns a dictionary with the added and deleted lines.
         The dictionary has 2 keys: "added" and "deleted", each containing the
@@ -353,9 +353,6 @@ class ModifiedFile:
 
         :return: Dictionary
         """
-        if not self.diff:
-            return None
-
         lines = self.diff.split("\n")
         modified_lines = {
             "added": [],
@@ -423,7 +420,7 @@ class ModifiedFile:
         return self._function_list_before
 
     @property
-    def changed_methods(self) -> Optional[List[Method]]:
+    def changed_methods(self) -> List[Method]:
         """
         Return the list of methods that were changed. This analysis
         is more complex because Lizard runs twice: for methods before
@@ -431,8 +428,6 @@ class ModifiedFile:
 
         :return: list of methods
         """
-        if not self.diff_parsed:
-            return None
         new_methods = self.methods
         old_methods = self.methods_before
         added = self.diff_parsed["added"]

--- a/pydriller/domain/commit.py
+++ b/pydriller/domain/commit.py
@@ -182,7 +182,7 @@ class ModifiedFile:
     @property
     def change_type(self) -> ModificationType:
         return self._from_change_to_modification_type(self._c_diff)
-        
+
     @staticmethod
     def _from_change_to_modification_type(diff: Diff) -> ModificationType:
         if diff.new_file:
@@ -195,11 +195,11 @@ class ModifiedFile:
             return ModificationType.MODIFY
 
         return ModificationType.UNKNOWN
-    
+
     @property
     def diff(self) -> str:
         return self._get_decoded_str(self._c_diff.diff) or ''
-    
+
     def _get_decoded_str(self, diff: Union[str, bytes, None]) -> Optional[str]:
         try:
             if type(diff) == bytes:
@@ -210,11 +210,11 @@ class ModifiedFile:
         except (AttributeError, ValueError):
             logger.debug(f"Could not load the diff of file {self.filename}")
             return None
-    
+
     @property
     def content(self) -> Optional[bytes]:
         return self._get_undecoded_content(self._c_diff.b_blob)
-    
+
     @property
     def content_before(self) -> Optional[bytes]:
         return self._get_undecoded_content(self._c_diff.a_blob)
@@ -355,7 +355,7 @@ class ModifiedFile:
         """
         if not self.diff:
             return None
-        
+
         lines = self.diff.split("\n")
         modified_lines = {
             "added": [],

--- a/pydriller/domain/commit.py
+++ b/pydriller/domain/commit.py
@@ -243,9 +243,6 @@ class ModifiedFile:
 
         :return: int lines_added
         """
-        if not self.diff:
-            return None
-        
         added_lines = 0
         for line in self.diff.replace("\r", "").split("\n"):
             if line.startswith("+") and not line.startswith("+++"):
@@ -259,9 +256,6 @@ class ModifiedFile:
 
         :return: int lines_deleted
         """
-        if not self.diff:
-            return None
-        
         deleted_lines = 0
         for line in self.diff.replace("\r", "").split("\n"):
             if line.startswith("-") and not line.startswith("---"):

--- a/pydriller/git.py
+++ b/pydriller/git.py
@@ -255,7 +255,7 @@ class Git:
             path = mod.new_path
             if mod.change_type == ModificationType.RENAME or mod.change_type == ModificationType.DELETE:
                 path = mod.old_path
-            
+
             if not mod.diff_parsed:
                 continue
             deleted_lines = mod.diff_parsed['deleted']

--- a/pydriller/git.py
+++ b/pydriller/git.py
@@ -256,8 +256,6 @@ class Git:
             if mod.change_type == ModificationType.RENAME or mod.change_type == ModificationType.DELETE:
                 path = mod.old_path
 
-            if not mod.diff_parsed:
-                continue
             deleted_lines = mod.diff_parsed['deleted']
 
             assert path is not None, "We could not find the path to the file"

--- a/pydriller/git.py
+++ b/pydriller/git.py
@@ -255,6 +255,9 @@ class Git:
             path = mod.new_path
             if mod.change_type == ModificationType.RENAME or mod.change_type == ModificationType.DELETE:
                 path = mod.old_path
+            
+            if not mod.diff_parsed:
+                continue
             deleted_lines = mod.diff_parsed['deleted']
 
             assert path is not None, "We could not find the path to the file"

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,3 @@
+mock
 pytest
 psutil

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
 mock
+types-mock
 pytest
 psutil

--- a/tests/integration/test_commit_filters.py
+++ b/tests/integration/test_commit_filters.py
@@ -235,7 +235,7 @@ def test_filepath_with_since():
 
 
 def test_since_as_filter():
-    since_as_filter = datetime(2018, 6, 6, 0, 0, 0, tzinfo=timezone.utc)
+    since_as_filter = datetime(2018, 6, 6, tzinfo=timezone.utc)
 
     assert len(list(Repository(
         path_to_repo='test-repos/since_as_filter',

--- a/tests/test_commit.py
+++ b/tests/test_commit.py
@@ -17,7 +17,7 @@ from mock import patch
 import pytest
 import logging
 
-from pydriller.domain.commit import ModifiedFile, ModificationType
+from pydriller.domain.commit import ModifiedFile
 
 logging.basicConfig(
     format='%(asctime)s - %(levelname)s - %(message)s', level=logging.INFO)
@@ -40,6 +40,7 @@ def test_equal(repo: Git):
     assert c3 == c2
     assert c1 != c3
 
+
 @patch('git.diff.Diff')
 def test_filename(mocked_diff):
     mocked_diff.a_path = 'dspadini/pydriller/myfile.py'
@@ -51,6 +52,7 @@ def test_filename(mocked_diff):
 
     assert m1.new_path == 'dspadini/pydriller/mynewfile.py'
     assert m1.old_path == 'dspadini/pydriller/myfile.py'
+
 
 @patch('git.diff.Diff')
 def test_metrics_python(mocked_diff):
@@ -121,7 +123,8 @@ def test_changed_methods():
     mod = gr.get_commit(
         '9f6ddc2aac740a257af59a76860590cb8a84c77b').modified_files[0]
     assert len(mod.changed_methods) == 3
-        
+
+
 @patch('git.diff.Diff')
 def test_metrics_cpp(mocked_diff):
     with open('test-repos/lizard/FileCPP.cpp', 'rb') as f:
@@ -139,6 +142,7 @@ def test_metrics_cpp(mocked_diff):
 
     assert len(m1.methods) == 16
 
+
 @patch('git.diff.Diff')
 def test_metrics_java(mocked_diff):
     with open('test-repos/lizard/FileJava.java', 'rb') as f:
@@ -155,6 +159,7 @@ def test_metrics_java(mocked_diff):
     assert m1.complexity == 92
 
     assert len(m1.methods) == 46
+
 
 @patch('git.diff.Diff')
 def test_metrics_not_supported_file(mocked_diff):

--- a/tests/test_commit.py
+++ b/tests/test_commit.py
@@ -43,15 +43,15 @@ def test_equal(repo: Git):
 
 @patch('git.diff.Diff')
 def test_filename(mocked_diff):
-    mocked_diff.a_path = Path('dspadini/pydriller/myfile.py')
-    mocked_diff.b_path = Path('dspadini/pydriller/mynewfile.py')
+    mocked_diff.a_path = 'dspadini/pydriller/myfile.py'
+    mocked_diff.b_path = 'dspadini/pydriller/mynewfile.py'
 
     m1 = ModifiedFile(mocked_diff)
 
     assert m1.filename == 'mynewfile.py'
 
-    assert m1.new_path == 'dspadini/pydriller/mynewfile.py'
-    assert m1.old_path == 'dspadini/pydriller/myfile.py'
+    assert m1.new_path == str(Path('dspadini/pydriller/mynewfile.py'))
+    assert m1.old_path == str(Path('dspadini/pydriller/myfile.py'))
 
 
 @patch('git.diff.Diff')

--- a/tests/test_commit.py
+++ b/tests/test_commit.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from pydriller.git import Git
 from pathlib import Path
+from mock import patch
 import pytest
 import logging
 
@@ -39,42 +40,28 @@ def test_equal(repo: Git):
     assert c3 == c2
     assert c1 != c3
 
+@patch('git.diff.Diff')
+def test_filename(mocked_diff):
+    mocked_diff.a_path = 'dspadini/pydriller/myfile.py'
+    mocked_diff.b_path = 'dspadini/pydriller/mynewfile.py'
 
-def test_filename():
-    diff_and_sc = {
-        'diff': '',
-        'content': b'',
-        'content_before': b''
-    }
-    m1 = ModifiedFile('dspadini/pydriller/myfile.py',
-                      'dspadini/pydriller/mynewfile.py',
-                      ModificationType.ADD, diff_and_sc)
-    m3 = ModifiedFile('dspadini/pydriller/myfile.py',
-                      'dspadini/pydriller/mynewfile.py',
-                      ModificationType.ADD, diff_and_sc)
-    m2 = ModifiedFile('dspadini/pydriller/myfile.py',
-                      None,
-                      ModificationType.ADD, diff_and_sc)
+    m1 = ModifiedFile(mocked_diff)
 
     assert m1.filename == 'mynewfile.py'
-    assert m2.filename == 'myfile.py'
-    assert m1 != m2
-    assert m3 == m1
 
+    assert m1.new_path == 'dspadini/pydriller/mynewfile.py'
+    assert m1.old_path == 'dspadini/pydriller/myfile.py'
 
-def test_metrics_python():
+@patch('git.diff.Diff')
+def test_metrics_python(mocked_diff):
     with open('test-repos/lizard/git_repository.py', 'rb') as f:
         content = f.read()
 
-    diff_and_sc = {
-        'diff': '',
-        'content': content,
-        'content_before': content
-    }
+    mocked_diff.a_path = 'test-repos/lizard/git_repository.py'
+    mocked_diff.b_path = "test-repos/lizard/git_repository.py"
+    mocked_diff.b_blob.data_stream.read.return_value = content
 
-    m1 = ModifiedFile('test-repos/lizard/git_repository.py',
-                      "test-repos/lizard/git_repository.py",
-                      ModificationType.MODIFY, diff_and_sc)
+    m1 = ModifiedFile(mocked_diff)
 
     assert m1.nloc == 196
     assert m1.token_count == 1009
@@ -134,21 +121,17 @@ def test_changed_methods():
     mod = gr.get_commit(
         '9f6ddc2aac740a257af59a76860590cb8a84c77b').modified_files[0]
     assert len(mod.changed_methods) == 3
-
-
-def test_metrics_cpp():
+        
+@patch('git.diff.Diff')
+def test_metrics_cpp(mocked_diff):
     with open('test-repos/lizard/FileCPP.cpp', 'rb') as f:
         content = f.read()
 
-    diff_and_sc = {
-        'diff': '',
-        'content': content,
-        'content_before': content
-    }
+    mocked_diff.a_path = 'test-repos/lizard/FileCPP.cpp'
+    mocked_diff.b_path = "test-repos/lizard/FileCPP.cpp"
+    mocked_diff.b_blob.data_stream.read.return_value = content
 
-    m1 = ModifiedFile('test-repos/lizard/FileCPP.cpp',
-                      "test-repos/lizard/FileCPP.cpp",
-                      ModificationType.MODIFY, diff_and_sc)
+    m1 = ModifiedFile(mocked_diff)
 
     assert m1.nloc == 793
     assert m1.token_count == 5564
@@ -156,20 +139,16 @@ def test_metrics_cpp():
 
     assert len(m1.methods) == 16
 
-
-def test_metrics_java():
+@patch('git.diff.Diff')
+def test_metrics_java(mocked_diff):
     with open('test-repos/lizard/FileJava.java', 'rb') as f:
         content = f.read()
 
-    diff_and_sc = {
-        'diff': '',
-        'content': content,
-        'content_before': content
-    }
+    mocked_diff.a_path = 'test-repos/lizard/FileJava.java'
+    mocked_diff.b_path = "test-repos/lizard/FileJava.java"
+    mocked_diff.b_blob.data_stream.read.return_value = content
 
-    m1 = ModifiedFile('test-repos/lizard/FileJava.java',
-                      "test-repos/lizard/FileJava.java",
-                      ModificationType.MODIFY, diff_and_sc)
+    m1 = ModifiedFile(mocked_diff)
 
     assert m1.nloc == 466
     assert m1.token_count == 3809
@@ -177,19 +156,13 @@ def test_metrics_java():
 
     assert len(m1.methods) == 46
 
-
-def test_metrics_not_supported_file():
+@patch('git.diff.Diff')
+def test_metrics_not_supported_file(mocked_diff):
     content = b'asd !&%@*&^@\n jjdkj'
 
-    diff_and_sc = {
-        'diff': '',
-        'content': content,
-        'content_before': content
-    }
+    mocked_diff.b_blob.data_stream.read.return_value = content
 
-    m1 = ModifiedFile('test-repos/lizard/NotSupported.pdf',
-                      "test-repos/lizard/NotSupported.pdf",
-                      ModificationType.MODIFY, diff_and_sc)
+    m1 = ModifiedFile(mocked_diff)
 
     assert m1.nloc is None
 

--- a/tests/test_commit.py
+++ b/tests/test_commit.py
@@ -43,8 +43,8 @@ def test_equal(repo: Git):
 
 @patch('git.diff.Diff')
 def test_filename(mocked_diff):
-    mocked_diff.a_path = 'dspadini/pydriller/myfile.py'
-    mocked_diff.b_path = 'dspadini/pydriller/mynewfile.py'
+    mocked_diff.a_path = Path('dspadini/pydriller/myfile.py')
+    mocked_diff.b_path = Path('dspadini/pydriller/mynewfile.py')
 
     m1 = ModifiedFile(mocked_diff)
 

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -28,6 +28,7 @@ def modification(request):
                          [("test-repos/diff", "9a985d4a12a3a12f009ef39750fd9b2187b766d1")],
                          indirect=True)
 def test_extract_line_number_and_content(modification: ModifiedFile):
+    assert modification.diff_parsed
     added = modification.diff_parsed['added']
     deleted = modification.diff_parsed['deleted']
 
@@ -42,6 +43,7 @@ def test_extract_line_number_and_content(modification: ModifiedFile):
                          [("test-repos/diff", "f45ee2f8976d5f018a1e4ec83eb4556a3df8b0a5")],
                          indirect=True)
 def test_additions(modification: ModifiedFile):
+    assert modification.diff_parsed
     added = modification.diff_parsed['added']
     deleted = modification.diff_parsed['deleted']
 
@@ -58,6 +60,7 @@ def test_additions(modification: ModifiedFile):
                          [("test-repos/diff", "147c7ce9f725a0e259d63f0bf4e6c8ac085ff8c8")],
                          indirect=True)
 def test_deletions(modification: ModifiedFile):
+    assert modification.diff_parsed
     added = modification.diff_parsed['added']
     deleted = modification.diff_parsed['deleted']
 
@@ -86,6 +89,7 @@ def test_diff_no_newline(modification: ModifiedFile):
         \\ No newline at end of file
     in diffs. This test asserts these additional lines are parsed correctly.
     """
+    assert modification.diff_parsed
     added = modification.diff_parsed['added']
     deleted = modification.diff_parsed['deleted']
 

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -242,6 +242,7 @@ def test_should_detail_a_commit(repo: Git):
     assert len(commit.modified_files) == 1
 
     assert commit.modified_files[0].new_path == "Matricula.java"
+    assert commit.modified_files[0].diff
     assert commit.modified_files[0].diff.startswith("@@ -0,0 +1,62 @@\n+package model;") is True
     assert commit.modified_files[0].content is not None
     assert commit.modified_files[0].content.decode().startswith("package model;") is True


### PR DESCRIPTION
I noticed that we ask for diffs, source code before and after the change, in a block. Which means, every time we ask for a diff, we also get source code before and after. Which is a waste of time and resources. 
So I brought the computation of source code and diff to the modified file, and it's computed only when requested.