### PR TITLE
Stop using GitPython to parse git stats

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-gitpython==3.1.30
+gitpython
 pytz
 types-pytz
 lizard


### PR DESCRIPTION
GitPython now ignores renames, which breaks Pydriller.

I created 2 functions to parse git stats result (same as GitPython), so we can do it "in-house".

Removing the constraint for GitPython=30 as well.
