### PR TITLE
Add support for co-author retrieval

### DIFF
--- a/pydriller/domain/commit.py
+++ b/pydriller/domain/commit.py
@@ -577,6 +577,22 @@ class Commit:
         )
 
     @property
+    def co_authors(self) -> List[Developer]:
+        """
+        Return the co-authors of the commit as a list of Developer objects.
+
+        :return: List[Developer] author
+        """
+        co_authors = []
+        for co_author in self._c_object.co_authors:
+            d = Developer(
+                co_author.name, co_author.email
+            )
+            co_authors.append(d)
+
+        return co_authors
+
+    @property
     def committer(self) -> Developer:
         """
         Return the committer of the commit as a Developer object.

--- a/tests/test_commit.py
+++ b/tests/test_commit.py
@@ -421,3 +421,11 @@ def test_modification_dictset(repo: Git):
     assert isinstance(mod_set, set)
     assert m1 in mod_set
     assert mod_set - {m1} == set(m2s)
+
+
+@pytest.mark.parametrize('repo', ['test-repos/multiple_authors'], indirect=True)
+def test_co_authors(repo: Git):
+    c1 = repo.get_commit('a455e6c8ba6960aa8b89bd0fd5f9abefcd10bcd6')
+
+    assert c1.co_authors[0].name == "Somebody"
+    assert c1.co_authors[0].email == "some@body.org"


### PR DESCRIPTION
GitPython has support to parse co-authors of commits from commit messages: https://github.com/gitpython-developers/GitPython/pull/1482
I would like to have that supported in pydriller too.
This commit adds a property `co_authors` to the `Commit` class, adds a unit test and a test case in a test repository.