### PR TITLE
Add diff function in git.py

### DIFF
--- a/pydriller/git.py
+++ b/pydriller/git.py
@@ -244,6 +244,17 @@ class Git:
         return self._calculate_last_commits(commit, modifications,
                                             hashes_to_ignore_path)
 
+    def diff(self, from_commit_id: str, to_commit_id: str) -> List[ModifiedFile]:
+        from_commit = self.repo.commit(from_commit_id)
+        to_commit = self.repo.commit(to_commit_id)
+        diff_index = from_commit.diff(
+            other=to_commit,
+            paths=None,
+            create_patch=True)
+        
+        modified_files_list = [ModifiedFile(diff=diff) for diff in diff_index]
+        return modified_files_list
+
     def _calculate_last_commits(self, commit: Commit,
                                 modifications: List[ModifiedFile],
                                 hashes_to_ignore_path: Optional[str] = None) \

--- a/pydriller/git.py
+++ b/pydriller/git.py
@@ -251,7 +251,7 @@ class Git:
             other=to_commit,
             paths=None,
             create_patch=True)
-        
+
         modified_files_list = [ModifiedFile(diff=diff) for diff in diff_index]
         return modified_files_list
 

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -506,7 +506,7 @@ def test_diff_function_in_git(repo: Git):
     from_commit_id = "9e9473d5ca310b7663e9df93c402302b6b7f24aa"
     to_commit_id = "b267a14e0503fdac36d280422f16360d1f661f12"
     modied_files = repo.diff(from_commit_id, to_commit_id)
-    
+
     diff = modied_files[0].diff
 
     assert len(modied_files) == 1

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -500,3 +500,20 @@ def test_get_commits_last_modified_lines_hyper_blame_with_renaming(repo: Git):
         'A.java']
     assert '9568d20856728304ab0b4d2d02fb9e81d0e5156d' in buggy_commits[
         'H.java']
+
+@pytest.mark.parametrize('repo', ["test-repos/diff"], indirect=True)
+def test_diff_function_in_git(repo: Git):
+    from_commit_id = "9e9473d5ca310b7663e9df93c402302b6b7f24aa"
+    to_commit_id = "b267a14e0503fdac36d280422f16360d1f661f12"
+    modied_files = repo.diff(from_commit_id, to_commit_id)
+    
+    diff = modied_files[0].diff
+
+    assert len(modied_files) == 1
+    assert "@@ -107,7 +107,7 @@ public class GitRepository implements SCM {" in diff
+    assert "     }" in diff
+    assert "     public static SCMRepository completelyNewName(String path) {" in diff
+    assert "-        return allProjectsIn(path, false);" in diff
+    assert "+        return new GitRepository(path).info();" in diff
+    assert "     }" in diff
+    assert "     public static SCMRepository singleProject(String path, boolean singleParentOnly) {" in diff

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -501,6 +501,7 @@ def test_get_commits_last_modified_lines_hyper_blame_with_renaming(repo: Git):
     assert '9568d20856728304ab0b4d2d02fb9e81d0e5156d' in buggy_commits[
         'H.java']
 
+
 @pytest.mark.parametrize('repo', ["test-repos/diff"], indirect=True)
 def test_diff_function_in_git(repo: Git):
     from_commit_id = "9e9473d5ca310b7663e9df93c402302b6b7f24aa"


### PR DESCRIPTION
This commit adds a diff function in git.py, which takes two commit ids and outputs a list of modified files.
Related issue: #278 