### PR TITLE
recognize "git://" prefix as remote repository

### DIFF
--- a/pydriller/repository.py
+++ b/pydriller/repository.py
@@ -149,7 +149,7 @@ class Repository:
 
     @staticmethod
     def _is_remote(repo: str) -> bool:
-        return repo.startswith(("git@", "https://", "http://"))
+        return repo.startswith(("git@", "https://", "http://", "git://"))
 
     def _clone_remote_repo(self, tmp_folder: str, repo: str) -> str:
         repo_folder = os.path.join(tmp_folder, self._get_repo_name_from_url(repo))


### PR DESCRIPTION
Git works with the prefix:
```git clone git://git.tizen.org/platform/core/api/alarm```