### PR TITLE
Check for Git > 2.38

### DIFF
--- a/pydriller/domain/__init__.py
+++ b/pydriller/domain/__init__.py
@@ -1,0 +1,4 @@
+from pydriller.utils.check_git_version import CheckGitVersion
+
+
+CheckGitVersion().check_git_version()

--- a/pydriller/utils/check_git_version.py
+++ b/pydriller/utils/check_git_version.py
@@ -1,0 +1,16 @@
+from importlib.metadata import version
+import re
+
+
+class GitVersion(Exception):
+    def __init__(self, message):
+        super().__init__(message)
+
+class CheckGitVersion:
+    def check_git_version(self):
+        git_version = version("gitpython")
+        version_number = re.findall(r"[0-9]+\.[0-9]+", git_version)[0]
+        if float(version_number) < 2.38:
+            raise GitVersion(
+                f"Current gitpython version is {version('gitpython')}. \n It can be upgraded with the following command: pip install gitpython --upgrade"
+            )

--- a/tests/test_check_git_version.py
+++ b/tests/test_check_git_version.py
@@ -1,0 +1,22 @@
+from pydriller.utils.check_git_version import CheckGitVersion, GitVersion
+from pytest_mock import MockerFixture
+from contextlib import nullcontext as does_not_raise
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "version_number,expectation",
+    [
+        ("3.2.0", does_not_raise()),
+        ("2.38.1", does_not_raise()),
+        ("2.0.0", pytest.raises(GitVersion)),
+    ],
+)
+def test_extracts_correct_version(mocker: MockerFixture, version_number, expectation):
+    mocker.patch(
+        "pydriller.utils.check_git_version.version",
+        return_value=version_number,
+    )
+    with expectation:
+        CheckGitVersion().check_git_version()


### PR DESCRIPTION
Added check for Git version and unit tests.  

`GitVersion` Exception will be raised if a compatible version is not found.

Closes #274 