### PR TITLE
Handle exception when analyzing an empty repository

### DIFF
--- a/pydriller/git.py
+++ b/pydriller/git.py
@@ -121,8 +121,11 @@ class Git:
         try:
             for commit in self.repo.iter_commits(rev=rev, **kwargs):
                 yield self.get_commit_from_gitpython(commit)
-        except GitCommandError:
-            logger.debug(f"Could not find commits in {self.path}")
+        except GitCommandError as gce:
+            if "fatal: bad revision 'HEAD'" in str(gce):
+                logger.debug(f"Could not find commits in {self.path}")
+            else:
+                raise Exception(f"Error while getting commits: {gce}")
 
     def get_commit(self, commit_id: str) -> Commit:
         """

--- a/pydriller/git.py
+++ b/pydriller/git.py
@@ -118,8 +118,11 @@ class Git:
         if 'reverse' not in kwargs:
             kwargs['reverse'] = True
 
-        for commit in self.repo.iter_commits(rev=rev, **kwargs):
-            yield self.get_commit_from_gitpython(commit)
+        try:
+            for commit in self.repo.iter_commits(rev=rev, **kwargs):
+                yield self.get_commit_from_gitpython(commit)
+        except GitCommandError:
+            logger.debug(f"Could not find commits in {self.path}")
 
     def get_commit(self, commit_id: str) -> Commit:
         """

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -42,10 +42,12 @@ def test_get_head(repo: Git):
     assert cs.hash == 'da39b1326dbc2edfe518b90672734a08f3c13458'
     assert cs.author_date.timestamp() == 1522164679
 
+    
 @pytest.mark.parametrize('repo', ['test-repos/empty_repo/'], indirect=True)
 def test_empty_repo(repo: Git):
     change_sets = list(repo.get_list_commits())
     assert change_sets == []
+
 
 @pytest.mark.parametrize('repo', ['test-repos/small_repo/'], indirect=True)
 def test_list_commits(repo: Git):

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -42,7 +42,7 @@ def test_get_head(repo: Git):
     assert cs.hash == 'da39b1326dbc2edfe518b90672734a08f3c13458'
     assert cs.author_date.timestamp() == 1522164679
 
-    
+
 @pytest.mark.parametrize('repo', ['test-repos/empty_repo/'], indirect=True)
 def test_empty_repo(repo: Git):
     change_sets = list(repo.get_list_commits())

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -42,6 +42,10 @@ def test_get_head(repo: Git):
     assert cs.hash == 'da39b1326dbc2edfe518b90672734a08f3c13458'
     assert cs.author_date.timestamp() == 1522164679
 
+@pytest.mark.parametrize('repo', ['test-repos/empty_repo/'], indirect=True)
+def test_empty_repo(repo: Git):
+    change_sets = list(repo.get_list_commits())
+    assert change_sets == []
 
 @pytest.mark.parametrize('repo', ['test-repos/small_repo/'], indirect=True)
 def test_list_commits(repo: Git):


### PR DESCRIPTION
It might seem obvious to run this tool on a non-empty repository, but for few use cases like integrating this tool as part of an automated pipeline to analyze several repositories there might be few empty repositories. When ran on an empty repository, it fails to `iter_commits` and throws the following error:

```sh
git.exc.GitCommandError: Cmd('git') failed due to: exit code(128)
cmdline: git rev-list --reverse HEAD --
stderr: 'fatal: bad revision 'HEAD'
```

To fix this, I followed the same approach adapted in `get_commits_modified_file` method to handle empty modifications by checking _`GitCommandError`_ exception ([ref](https://github.com/ishepard/pydriller/blob/aed5f5bb8112c12153bfb8f20e5b9ad2a10d985d/pydriller/git.py#L332)). I have added the test case and added it's corresponding repository in the `.zip` file. 