### PR TITLE
Fix some small formatting faults in the documentation

### DIFF
--- a/docs/modifiedfile.rst
+++ b/docs/modifiedfile.rst
@@ -6,16 +6,16 @@ ModifiedFile
 
 You can get a list of modified files as well as their diffs and current source code from each commit. All *Modifications* can be obtained by iterating over the ModifiedFile object. Each modification object references a modified file and has the following fields:
 
-* **old_path**: old path of the file (can be _None_ if the file is added)
-* **new_path**: new path of the file (can be _None_ if the file is deleted)
+* **old_path**: old path of the file (can be ``None`` if the file is added)
+* **new_path**: new path of the file (can be ``None`` if the file is deleted)
 * **filename**: return only the filename (e.g., given a path-like-string such as "/Users/dspadini/pydriller/myfile.py" returns “myfile.py”)
 * **change_type**: type of the change: can be Added, Deleted, Modified, or Renamed. If you use `change_type.name` you get `ADD`, `DELETE`, `MODIFY`, `RENAME`.
 * **diff**: diff of the file as Git presents it (e.g., starting with @@ xx,xx @@).
 * **diff_parsed**: diff parsed in a dictionary containing the added and deleted lines. The dictionary has 2 keys: “added” and “deleted”, each containing a list of Tuple (int, str) corresponding to (number of line in the file, actual line).
 * **added_lines**: number of lines added
 * **deleted_lines**: number of lines removed
-* **source_code**: source code of the file (can be _None_ if the file is deleted or only renamed)
-* **source_code_before**: source code of the file before the change (can be _None_ if the file is added or only renamed)
+* **source_code**: source code of the file (can be ``None`` if the file is deleted or only renamed)
+* **source_code_before**: source code of the file before the change (can be ``None`` if the file is added or only renamed)
 * **methods**: list of methods of the file. The list might be empty if the programming language is not supported or if the file is not a source code file. These are the methods **after** the change.
 * **methods_before**: list of methods of the file **before** the change (e.g., before the commit.)
 * **changed_methods**: subset of _methods_ containing **only** the changed methods. 

--- a/docs/modifiedfile.rst
+++ b/docs/modifiedfile.rst
@@ -18,7 +18,7 @@ You can get a list of modified files as well as their diffs and current source c
 * **source_code_before**: source code of the file before the change (can be ``None`` if the file is added or only renamed)
 * **methods**: list of methods of the file. The list might be empty if the programming language is not supported or if the file is not a source code file. These are the methods **after** the change.
 * **methods_before**: list of methods of the file **before** the change (e.g., before the commit.)
-* **changed_methods**: subset of _methods_ containing **only** the changed methods. 
+* **changed_methods**: subset of *methods* containing **only** the changed methods. 
 * **nloc**: Lines Of Code (LOC) of the file
 * **complexity**: Cyclomatic Complexity of the file
 * **token_count**: Number of Tokens of the file


### PR DESCRIPTION
At some points in the documentation, there is [markdown syntax for italic](https://www.markdownguide.org/basic-syntax/#italic) in use, instead of the [reStructuredText syntax](https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#inline-markup). This Pull Request fixes that, in assumption that `None` should be better formatted as a code sample, like at other parts of the documentation.