### PR TITLE
fix: respect skip_whitespaces option in Commit._stats()

### DIFF
--- a/pydriller/domain/commit.py
+++ b/pydriller/domain/commit.py
@@ -691,20 +691,25 @@ class Commit:
     def _stats(self):
         if self._stats_cache is not None:
             return self._stats_cache
-        
+
         options = {}
         if self._conf.get("skip_whitespaces"):
             options["w"] = True
 
         if len(self.parents) == 0:
-            text = self._conf.get('git').repo.git.diff_tree(self.hash, "--", numstat=True, root=True, **options)
+            text = self._conf.get('git').repo.git.diff_tree(
+                self.hash, "--", numstat=True, root=True, **options
+            )
             text2 = ""
             for line in text.splitlines()[1:]:
                 (insertions, deletions, filename) = line.split("\t")
                 text2 += "%s\t%s\t%s\n" % (insertions, deletions, filename)
             text = text2
         else:
-            text = self._conf.get('git').repo.git.diff(self._c_object.parents[0].hexsha, self._c_object.hexsha, "--", numstat=True, root=True, **options)
+            text = self._conf.get('git').repo.git.diff(
+                self._c_object.parents[0].hexsha, self._c_object.hexsha,
+                "--", numstat=True, root=True, **options
+            )
 
         self._stats_cache = self._list_from_string(text)
         return self._stats_cache

--- a/pydriller/domain/commit.py
+++ b/pydriller/domain/commit.py
@@ -691,16 +691,20 @@ class Commit:
     def _stats(self):
         if self._stats_cache is not None:
             return self._stats_cache
+        
+        options = {}
+        if self._conf.get("skip_whitespaces"):
+            options["w"] = True
 
         if len(self.parents) == 0:
-            text = self._conf.get('git').repo.git.diff_tree(self.hash, "--", numstat=True, root=True)
+            text = self._conf.get('git').repo.git.diff_tree(self.hash, "--", numstat=True, root=True, **options)
             text2 = ""
             for line in text.splitlines()[1:]:
                 (insertions, deletions, filename) = line.split("\t")
                 text2 += "%s\t%s\t%s\n" % (insertions, deletions, filename)
             text = text2
         else:
-            text = self._conf.get('git').repo.git.diff(self._c_object.parents[0].hexsha, self._c_object.hexsha, "--", numstat=True, root=True)
+            text = self._conf.get('git').repo.git.diff(self._c_object.parents[0].hexsha, self._c_object.hexsha, "--", numstat=True, root=True, **options)
 
         self._stats_cache = self._list_from_string(text)
         return self._stats_cache

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -217,6 +217,18 @@ def test_ignore_add_whitespaces_and_changed_file():
     assert len(commit.modified_files) == 1
 
 
+def test_ignore_whitespaces_in_stats():
+    for commit in Repository('test-repos/whitespace',
+                             single="338a74ceae164784e216555d930210371279ba8e").traverse_commits():
+        assert commit.insertions > 0
+
+    for commit in Repository('test-repos/whitespace',
+                             skip_whitespaces=True,
+                             single="338a74ceae164784e216555d930210371279ba8e").traverse_commits():
+        assert commit.insertions == 0
+        assert commit.deletions == 0
+
+
 def test_clone_repo_to(tmp_path):
     dt2 = datetime(2018, 10, 20)
     url = "https://github.com/ishepard/pydriller.git"


### PR DESCRIPTION
Fixes #317

`Commit._stats()` didn't pass the `skip_whitespaces` option to either of its two git calls (`diff_tree` for root commits, `diff` for others), while `Commit.modified_files` already did. This caused `insertions`/`deletions` to disagree with `diff_parsed`'s `added`/`deleted` counts whenever a commit contained only whitespace changes and `skip_whitespaces=True` was set.

Fix: build an `options` dict from `skip_whitespaces` (matching the existing pattern in `modified_files`) and pass it as `**options` into both git calls in `_stats()`.

Verified with a small local repo containing a whitespace-only commit:
- `skip_whitespaces=True`: insertions/deletions and adds/dels both report `0` (correctly ignored)
- `skip_whitespaces=False`: both report `1` (correctly counted)

Full existing test suite (`tests/test_commit.py`) still passes - 27/27.