### PR TITLE
Add commit patch property

### DIFF
--- a/pydriller/domain/commit.py
+++ b/pydriller/domain/commit.py
@@ -714,6 +714,34 @@ class Commit:
         self._stats_cache = self._list_from_string(text)
         return self._stats_cache
 
+    @property
+    def patch(self) -> str:
+        """
+        Return the entire patch of the commit, as Git would show it
+        (equivalent to "git show <hash>" or a GitHub ".patch" URL).
+
+        NOTE: returns an empty string for merge commits. Merge commits
+        make up a meaningful fraction of commits in most repositories,
+        and combined-diff parsing for merges is not currently supported
+        by PyDriller (the same limitation applies to modified_files).
+        Check commit.merge before relying on this property if your use
+        case needs merge-commit patches too.
+
+        :return: str patch
+        """
+        git_repo = self._conf.get('git')
+
+        if len(self.parents) > 1:
+            return ''
+
+        if len(self.parents) == 0:
+            text = git_repo.repo.git.diff_tree(self.hash, "-p", "--root", "--")
+            return "\n".join(text.splitlines()[1:])
+
+        return git_repo.repo.git.diff(
+            self._c_object.parents[0].hexsha, self._c_object.hexsha
+        )
+
     def _list_from_string(self, text: str):
         total = {"insertions": 0, "deletions": 0, "lines": 0, "files": 0}
 

--- a/tests/test_commit.py
+++ b/tests/test_commit.py
@@ -381,6 +381,27 @@ def test_shortstats_add_and_del(repo: Git):
     assert c1.deletions == 1
 
 
+@pytest.mark.parametrize('repo', ['test-repos/small_repo'], indirect=True)
+def test_patch_root_commit(repo: Git):
+    commit = repo.get_commit('a88c84ddf42066611e76e6cb690144e5357d132c')
+    assert commit.patch.startswith('diff --git')
+    assert 'new file mode' in commit.patch
+
+
+@pytest.mark.parametrize('repo', ['test-repos/small_repo'], indirect=True)
+def test_patch_normal_commit(repo: Git):
+    commit = repo.get_commit('6411e3096dd2070438a17b225f44475136e54e3a')
+    assert commit.patch.startswith('diff --git')
+    assert '-    public boolean isMerge() {' in commit.patch
+
+
+@pytest.mark.parametrize('repo', ['test-repos/branches_merged'], indirect=True)
+def test_patch_merge_commit(repo: Git):
+    commit = repo.get_commit('29e929fbc5dc6a2e9c620069b24e2a143af4285f')
+    assert commit.merge is True
+    assert commit.patch == ''
+
+
 @pytest.mark.parametrize("repo", ["test-repos/complex_repo"], indirect=True)
 def test_commit_dictset(repo: Git):
     c1 = repo.get_commit("e7d13b0511f8a176284ce4f92ed8c6e8d09c77f2")


### PR DESCRIPTION
Fixes #226

Adds `Commit.patch`, returning the full unified diff of a commit as
Git would show it (equivalent to `git show <hash>` or a GitHub
".patch" URL), rather than the per-file, already-parsed view that
`modified_files` provides.

Implementation delegates directly to git itself (`git diff` /
`git diff_tree -p --root`) rather than reconstructing patch headers
manually, matching the existing pattern in `_stats()`.

Behavior:
- Normal commits: returns the full patch via `git diff <parent> <hash>`.
- Root commits (no parent): uses `git diff_tree -p --root`, stripping
  the leading commit-hash line that diff_tree prints before the diff.
- Merge commits: returns an empty string. This matches the existing
  precedent in `modified_files`, which also returns an empty list for
  merges, since combined-diff parsing for merges isn't currently
  supported. Worth noting merge commits aren't rare in most repos
  (~15% of commits in this repo, for example), so this is a real,
  documented limitation, not just an edge case.

Note: like `_stats()` / `.insertions` / `.deletions`, this property
depends on `self._conf.get('git')`, which is only live while
`Repository`'s context manager is open. Calling `.patch` on a commit
after fully materializing `Repository(...).traverse_commits()` with
`list(...)` will hit the same issue described in #283. Using the
`Git` class directly (as in the tests here) isn't affected, since it
never nulls out `conf['git']`.

Tests added in tests/test_commit.py covering root, normal, and merge
commit cases using existing fixtures (small_repo, branches_merged).
Full test suite passes (306/306), flake8 and mypy clean.