### PR TITLE
Accept PathLike objects as repository paths

### DIFF
--- a/pydriller/repository.py
+++ b/pydriller/repository.py
@@ -41,7 +41,7 @@ class Repository:
     This is the main class of PyDriller, responsible for running the study.
     """
 
-    def __init__(self, path_to_repo: Union[str, List[str]],
+    def __init__(self, path_to_repo: Union[str, os.PathLike, List[Union[str, os.PathLike]]],
                  single: Optional[str] = None,
                  since: Optional[datetime] = None, since_as_filter: Optional[datetime] = None, to: Optional[datetime] = None,
                  from_commit: Optional[str] = None, to_commit: Optional[str] = None,
@@ -73,8 +73,10 @@ class Repository:
         repo; if you pass an URL, PyDriller will clone the repo in a
         temporary folder, run the study, and delete the temporary folder.
 
-        :param Union[str,List[str]] path_to_repo: absolute path (or list of
-            absolute paths) to the repository(ies) to analyze
+        :param path_to_repo: absolute path (or list of absolute paths) to the
+            repository(ies) to analyze. Each path can be a string or any
+            os.PathLike object (e.g. a pathlib.Path); remote repositories must
+            be passed as a URL string.
         :param str single: hash of a single commit to analyze
         :param datetime since: starting date
         :param datetime since_as_filter: starting date (scans all commits, does not stop at first commit with date < since_as_filter)

--- a/pydriller/utils/conf.py
+++ b/pydriller/utils/conf.py
@@ -3,6 +3,7 @@ Configuration module.
 """
 
 import logging
+import os
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple, Union
 
@@ -30,10 +31,11 @@ class Conf:
             self._options[key] = val
 
         self._sanity_check_repos(self.get('path_to_repo'))
-        if isinstance(self.get('path_to_repo'), str):
-            self.set_value('path_to_repos', [self.get('path_to_repo')])
+        if isinstance(self.get('path_to_repo'), (str, os.PathLike)):
+            self.set_value('path_to_repos', [os.fspath(self.get('path_to_repo'))])
         else:
-            self.set_value('path_to_repos', self.get('path_to_repo'))
+            self.set_value('path_to_repos',
+                           [os.fspath(path) for path in self.get('path_to_repo')])
 
         if self._options.get("use_mailmap"):
             self.set_value("developer_factory", MailmapDeveloperFactory(self))
@@ -59,15 +61,18 @@ class Conf:
         return self._options.get(key, None)
 
     @staticmethod
-    def _sanity_check_repos(path_to_repo: Union[str, List[str]]) -> None:
+    def _sanity_check_repos(
+        path_to_repo: Union[str, os.PathLike, List[Union[str, os.PathLike]]]
+    ) -> None:
         """
-        Checks if repo is of type str or list.
+        Checks if repo is a str, a PathLike object, or a list of these.
 
         @param path_to_repo: path to the repo as provided by the user.
         @return:
         """
-        if not isinstance(path_to_repo, str) and not isinstance(path_to_repo, list):
-            raise Exception("The path to the repo has to be of type 'string' or 'list of strings'!")
+        if not isinstance(path_to_repo, (str, os.PathLike, list)):
+            raise Exception("The path to the repo has to be a string, a PathLike "
+                            "object, or a list of these!")
 
     def _check_only_one_from_commit(self) -> None:
         if not self.only_one_filter([self.get('since'),

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -1,5 +1,6 @@
 import logging
 from datetime import datetime
+from pathlib import Path
 import os
 import pytest
 import sys
@@ -58,6 +59,20 @@ def test_simple_url(repo, expected):
     ((["test-repos/small_repo", "test-repos/branches_merged"]), 9)
 ], indirect=['repo'])
 def test_two_local_urls(repo, expected):
+    assert len(repo) == expected
+
+
+@pytest.mark.parametrize('repo,expected', [
+    (Path("test-repos/small_repo"), 5)
+], indirect=['repo'])
+def test_simple_path_object(repo, expected):
+    assert len(repo) == expected
+
+
+@pytest.mark.parametrize('repo,expected', [
+    (([Path("test-repos/small_repo"), Path("test-repos/branches_merged")]), 9)
+], indirect=['repo'])
+def test_two_local_path_objects(repo, expected):
     assert len(repo) == expected
 
 


### PR DESCRIPTION
Fixes #315.

`Repository` only accepted a `str` or a list of `str` for `path_to_repo`, so passing a `pathlib.Path` raised "The path to the repo has to be of type 'string' or 'list of strings'!". This makes it accept any `os.PathLike` too, either on its own or inside the list, which lines up with what GitPython's `Repo` already does.

The paths get normalized with `os.fspath` in `Conf`, so the rest of the code keeps working with plain strings and remote URL strings are left untouched.

This picks up the abandoned #319 and adds the local-repo tests with `Path` objects that were asked for there.
